### PR TITLE
Update Ecto Lesson for Elixir 1.4

### DIFF
--- a/lessons/specifics/ecto.md
+++ b/lessons/specifics/ecto.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.1.0
 layout: page
 title: Ecto
 category: specifics


### PR DESCRIPTION
Changes default Application file from `<project name.ex>` to `application.ex`
Removes adding dependencies to application list
Adds requirement for `ecto.gen.repo` to have `-r` flag
Adds requirement for `config.exs` to have `ecto_repos` configuration
Adds instruction to run `mix ecto.create`
Indicates location of migration files
Adds `()` on `timestamps` function
Replaces Model with Schema