### PR TITLE
Update reference to Enum.chunk to modern Enum.chunk_every

### DIFF
--- a/en/lessons/basics/enum.md
+++ b/en/lessons/basics/enum.md
@@ -56,16 +56,16 @@ iex> Enum.any?(["foo", "bar", "hello"], fn(s) -> String.length(s) == 5 end)
 true
 ```
 
-### chunk
+### chunk_every
 
-If you need to break your collection up into smaller groups, `chunk/2` is the function you're probably looking for:
+If you need to break your collection up into smaller groups, `chunk_every/2` is the function you're probably looking for:
 
 ```elixir
-iex> Enum.chunk([1, 2, 3, 4, 5, 6], 2)
+iex> Enum.chunk_every([1, 2, 3, 4, 5, 6], 2)
 [[1, 2], [3, 4], [5, 6]]
 ```
 
-There are a few options for `chunk/2` but we won't go into them, check out [`the official documentation of this function`](https://hexdocs.pm/elixir/Enum.html#chunk/2) to learn more.
+There are a few options for `chunk_every/4` but we won't go into them, check out [`the official documentation of this function`](https://hexdocs.pm/elixir/Enum.html#chunk_every/4) to learn more.
 
 ### chunk_by
 


### PR DESCRIPTION
As stated, the live version is for `Enum.chunk` which doesn't exist in Elixir 1.5.1.

Alas, I'm not in a position to handle all the non-English translations.