### PR TITLE
Remove permanent scrollbar from the sidebar

### DIFF
--- a/_assets/stylesheets/custom.scss
+++ b/_assets/stylesheets/custom.scss
@@ -63,7 +63,7 @@ i.back-to-top {
  * Overrides theme's sidebar so content isn't cut off
  */
 .sidebar {
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .sidebar::-webkit-scrollbar {


### PR DESCRIPTION
The scrollbar in the sidebar is present even if the content doesn't overflow its box. [Example.](https://elixirschool.com/uk/)