### PR TITLE
Show contributors in each file by commit

### DIFF
--- a/_assets/javascripts/app.js
+++ b/_assets/javascripts/app.js
@@ -1,6 +1,7 @@
 /*
  *= require jquery
  *= require toc.js
+ *= require contributors.js
  */
 
 var swap_icon = function(el) {
@@ -42,5 +43,6 @@ $(function() {
     minimumHeaders: 0,
     backToTopClasses: 'icon icon-chevron-up2 back-to-top'
   });
+  $("#contributors").contributors();
   $('.version-info').click(show_vcs_history);
 });

--- a/_assets/javascripts/contributors.js
+++ b/_assets/javascripts/contributors.js
@@ -8,7 +8,9 @@
   };
 
   $.fn.contributors = function() {
-    var filePath = window.location.pathname.replace(/^\/(.*)\/$/, "$1.md");
+    var strippedPath = window.location.pathname.replace(/^\/(.*)\/$/, "$1");
+    var isIndex = strippedPath.indexOf('/') === -1
+    var filePath = isIndex ? strippedPath + '/index.md' : strippedPath + '.md'
     var commitsApiEndpoint = "https://api.github.com/repos/elixirschool/elixirschool/commits?path=" + filePath + "&per_page=100";
     var self = this;
     var statusElement = $(self).find(".status");

--- a/_assets/javascripts/contributors.js
+++ b/_assets/javascripts/contributors.js
@@ -22,15 +22,16 @@
         return commit.author.login;
       });
 
-      unique(usernames).forEach(function(username) {
-        var content = "" +
-          "<a class=\"tooltip\" href=\"https://github.com/" + username + "\">" +
-            "<img src=\"https://github.com/" + username + ".png?size=50\" >" +
-            "<span class=\"tooltiptext\">" + username + "</span>" +
-          "</a>";
+      var content = unique(usernames)
+        .reduce(function(accHtml, username) {
+          return accHtml +
+            "<a class=\"tooltip\" href=\"https://github.com/" + username + "\">" +
+              "<img src=\"https://github.com/" + username + ".png?size=50\" >" +
+              "<span class=\"tooltiptext\">" + username + "</span>" +
+            "</a>";
+        }, "")
 
-        $(self).append(content);
-      })
+      $(self).append(content);
     }
 
     try {

--- a/_assets/javascripts/contributors.js
+++ b/_assets/javascripts/contributors.js
@@ -1,0 +1,41 @@
+(function($) {
+  var unique = function(array) {
+    return array
+      .reduce(function(acc, curr) {
+        var isAppeared = acc.indexOf(curr) !== -1;
+        return isAppeared ? acc : acc.concat([curr]);
+      }, []);
+  };
+
+  $.fn.contributors = function() {
+    var filePath = window.location.pathname.replace(/^\/(.*)\/$/, "$1.md");
+    var commitsApiEndpoint = "https://api.github.com/repos/elixirschool/elixirschool/commits?path=" + filePath + "&per_page=100";
+    var self = this;
+    var statusElement = $(self).find(".status");
+
+    var populateContributors = function(commits) {
+      statusElement.remove()
+
+      var usernames = commits.map(function(commit) {
+        return commit.author.login;
+      });
+
+      unique(usernames).forEach(function(username) {
+        var content = "" +
+          "<a class=\"tooltip\" href=\"https://github.com/" + username + "\">" +
+            "<img src=\"https://github.com/" + username + ".png?size=50\" >" +
+            "<span class=\"tooltiptext\">" + username + "</span>" +
+          "</a>";
+
+        $(self).append(content);
+      })
+    }
+
+    try {
+      $.get(commitsApiEndpoint, populateContributors);
+    } catch (e) {
+      console.log(e);
+      statusElement.text('fail to fetch contributors from github');
+    }
+  };
+})(jQuery);

--- a/_assets/stylesheets/app.scss
+++ b/_assets/stylesheets/app.scss
@@ -4,6 +4,7 @@
 *= require hyde
 *= require custom
 *= require icons
+*= require contributors
 *= require social
 */
 

--- a/_assets/stylesheets/contributors.scss
+++ b/_assets/stylesheets/contributors.scss
@@ -1,0 +1,48 @@
+#contributors {
+  a {
+    margin: 5px;
+  }
+
+  img {
+    border: 1px dashed #4B365F;
+    display: inline;
+    max-width: 50px;
+  }
+
+  /* tooltip */
+  .tooltip {
+    position: relative;
+    display: inline-block;
+  }
+
+  .tooltip .tooltiptext {
+    width: 120px;
+    background-color: rgba(255,255,255,0);
+    color: #4B365F;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+
+    position: absolute;
+    z-index: 1;
+
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.5s linear;
+  }
+
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s linear;
+  }
+
+  .tooltip .tooltiptext {
+    width: 120px;
+    font-size: 0.7em;
+    top: 67%;
+    left: 50%; 
+    /* Use half of the width (120/2 = 60), to center the tooltip */
+    margin-left: -60px; 
+  }
+}

--- a/_assets/stylesheets/contributors.scss
+++ b/_assets/stylesheets/contributors.scss
@@ -6,7 +6,8 @@
   img {
     border: 1px dashed #4B365F;
     display: inline;
-    max-width: 50px;
+    width: 50px;
+    height: 50px;
   }
 
   /* tooltip */

--- a/_includes/contributors.html
+++ b/_includes/contributors.html
@@ -1,0 +1,6 @@
+<hr>
+<!-- populate by js -->
+<div id="contributors">
+  <h3>Contributors</h3>
+  <p class="status">loading...</p>
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,9 +11,9 @@ layout: default
 
   {{ content }}
 
-  {% include pagination.html %}
-
   {% include contributors.html %}
 
+  {% include pagination.html %}
+  
   {% include social.html %}
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,5 +13,7 @@ layout: default
 
   {% include pagination.html %}
 
+  {% include contributors.html %}
+
   {% include social.html %}
 </div>


### PR DESCRIPTION
Resolve #927

Using github api to query username from commit by file path.

There are 2 edge cases that haven't covered yet.
1. page can have only less than or equal 100 contributors due to github api per_page max is 100 or else need to fetch until next page is empty.
2. rate_limit for the api is 60 per hour so if we refresh page or navigate to new page more than that it  won't show contributors within 1 hour.