### PR TITLE
Fix Erlang timer.tc function returns time in microseconds not miliseconds

### DIFF
--- a/cn/lessons/advanced/erlang.md
+++ b/cn/lessons/advanced/erlang.md
@@ -16,13 +16,13 @@ title: 和 Erlang 互操作
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/de/lessons/advanced/erlang.md
+++ b/de/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Lass uns `:timer.tc` benutzen, um die Ausführungszeit einer gegebenen Funktion 
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/en/lessons/advanced/erlang.md
+++ b/en/lessons/advanced/erlang.md
@@ -19,13 +19,13 @@ Let's use `:timer.tc` to time execution of a given function:
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/es/lessons/advanced/erlang.md
+++ b/es/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Vamos a usar `:timer.tc` para medir el tiempo de ejecución de una función dada
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/gr/lessons/advanced/erlang.md
+++ b/gr/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ title: Διαλειτουργικότητα με την Erlang
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Χρόνος: #{time}ms"
+    IO.puts "Χρόνος: #{time} μs"
     IO.puts "Αποτέλεσμα: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Χρόνος: 8ms
+Χρόνος: 8 μs
 Αποτέλεσμα: 1000000
 ```
 

--- a/id/lessons/advanced/erlang.md
+++ b/id/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Mari gunakan `:timer.tc` untuk mengukur waktu eksekusi dari sebuah fungsi yang a
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/jp/lessons/advanced/erlang.md
+++ b/jp/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Erlangの豊富な標準ライブラリはアプリケーション内のどのEl
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/ko/lessons/advanced/erlang.md
+++ b/ko/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Erlang의 방대한 표준 라이브러리는 애플리케이션의 어떤 Elixi
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/my/lessons/advanced/erlang.md
+++ b/my/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Mari kita gunakan `:timer.tc` untuk mengukur masa yang digunakan untuk menjalank
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/pl/lessons/advanced/erlang.md
+++ b/pl/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Użyjmy `:timer.tc` by zmierzyć czas wykonania funkcji:
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 

--- a/pt/lessons/advanced/erlang.md
+++ b/pt/lessons/advanced/erlang.md
@@ -17,13 +17,13 @@ Vamos usar `:timer.tc` para medir o tempo de execução de uma determinada funç
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time}ms"
+    IO.puts "Time: #{time} μs"
     IO.puts "Result: #{result}"
   end
 end
 
 iex> Example.timed(fn (n) -> (n * n) * n end, [100])
-Time: 8ms
+Time: 8 μs
 Result: 1000000
 ```
 


### PR DESCRIPTION
8 ms for just three multiplications? This must be slow as 🐌