### PR TITLE
Added two new Map methods into autocomplete example

### DIFF
--- a/bn/lessons/basics/iex-helpers.md
+++ b/bn/lessons/basics/iex-helpers.md
@@ -23,8 +23,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 ### `.iex.exs`

--- a/en/lessons/basics/iex-helpers.md
+++ b/en/lessons/basics/iex-helpers.md
@@ -29,8 +29,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 And now we know the functions we have and their arity!

--- a/gr/lessons/basics/iex-helpers.md
+++ b/gr/lessons/basics/iex-helpers.md
@@ -27,8 +27,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 Και τώρα ξέρουμε τις συναρτήσεις που έχουμε και την τάξη τους.

--- a/ko/lessons/basics/iex-helpers.md
+++ b/ko/lessons/basics/iex-helpers.md
@@ -27,8 +27,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 그러면 지금 사용 가능한 함수와 각각의 애리티를 확인할 수 있습니다.

--- a/no/lessons/basics/iex-helpers.md
+++ b/no/lessons/basics/iex-helpers.md
@@ -26,8 +26,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 og nå kjenner vi til modulen sine funksjoner og deres aritet.

--- a/pl/lessons/basics/iex-helpers.md
+++ b/pl/lessons/basics/iex-helpers.md
@@ -27,8 +27,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 I już wiemy jakie funkcje są dostępne wraz z ich arnością!

--- a/pt/lessons/basics/iex-helpers.md
+++ b/pt/lessons/basics/iex-helpers.md
@@ -24,8 +24,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 E agora sabemos as funções que temos e seus números de argumentos!

--- a/sk/lessons/basics/iex-helpers.md
+++ b/sk/lessons/basics/iex-helpers.md
@@ -27,8 +27,9 @@ keys/1               merge/2              merge/3
 new/0                new/1                new/2
 pop/2                pop/3                pop_lazy/3
 put/3                put_new/3            put_new_lazy/3
-split/2              take/2               to_list/1
-update!/3            update/4             values/1
+replace!/3           replace/3            split/2
+take/2               to_list/1            update!/3
+update/4             values/1
 ```
 
 A teraz vieme aké funkcie máme k dispozícii!


### PR DESCRIPTION
In Map there are two methods not listed before: replace/3 and replace!/3.

I got to mention here that in Elixir 1.6 replace/3 will be deprecated: 
https://github.com/elixir-lang/elixir/commit/a81a17b3b09b267883383bdb8a00fe00ab2724a8#diff-6de3c4f6ae8d21f212a47e56ccdd4d77R18