### PR TITLE
Fix with/1 refactoring example inconsistency between case/2 and with/1 versions

### DIFF
--- a/bg/lessons/basics/control-structures.md
+++ b/bg/lessons/basics/control-structures.md
@@ -154,7 +154,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -167,6 +167,6 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```

--- a/bn/lessons/basics/control-structures.md
+++ b/bn/lessons/basics/control-structures.md
@@ -156,7 +156,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do 
   {:ok, user} -> 
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -169,7 +169,7 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```
 

--- a/de/lessons/basics/control-structures.md
+++ b/de/lessons/basics/control-structures.md
@@ -155,7 +155,7 @@ Lass uns nun ein längeres Beispiel ohne `with` anschauen und dann sehen, wie wi
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -168,6 +168,6 @@ Wenn wir `with` einführen, kommen wir zu Code, der einfach zu verstehen ist und
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -157,7 +157,7 @@ Now let's look at a larger example without `with/1` and then see how we can refa
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
       error -> error
@@ -170,7 +170,7 @@ When we introduce `with/1` we end up with code that is easy to understand and ha
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(token, full_claims)
 end
 ```

--- a/gr/lessons/basics/control-structures.md
+++ b/gr/lessons/basics/control-structures.md
@@ -155,7 +155,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -168,7 +168,7 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(jwt, full_claims)
 end
 ```

--- a/id/lessons/basics/control-structures.md
+++ b/id/lessons/basics/control-structures.md
@@ -153,7 +153,7 @@ Sekarang mari lihat contoh yang lebih besar tanpa `with` dan kemudian melihat ba
 ```elixir
 case Repo.insert(changeset) do 
   {:ok, user} -> 
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -166,6 +166,6 @@ Ketika kita menggunakan `with` kita dapati code yang mudah dipahami dan mengguna
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```

--- a/jp/lessons/basics/control-structures.md
+++ b/jp/lessons/basics/control-structures.md
@@ -155,7 +155,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -168,6 +168,6 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -154,7 +154,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
       error -> error
@@ -167,7 +167,7 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(token, full_claims)
 end
 ```

--- a/no/lessons/basics/control-structures.md
+++ b/no/lessons/basics/control-structures.md
@@ -158,7 +158,7 @@ La oss nå se på et større eksempel uten `with`, og deretter se hvordan vi kan
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -171,7 +171,7 @@ Når vi introduserer `with` til eksemplet, ender vi opp med kode som er enklere 
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```
 

--- a/pl/lessons/basics/control-structures.md
+++ b/pl/lessons/basics/control-structures.md
@@ -154,7 +154,7 @@ Teraz przyjrzyjmy się większemu przykładowi bez `with`, a następnie zrefakto
 ```elixir
 case Repo.insert(changeset) do 
   {:ok, user} -> 
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -167,7 +167,7 @@ Dzięki wprowadzeniu `with` nasz końcowy kod jest krótszy i łatwiejszy do zro
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```
 

--- a/ru/lessons/basics/control-structures.md
+++ b/ru/lessons/basics/control-structures.md
@@ -154,7 +154,7 @@ iex> with {:ok, first} <- Map.fetch(user, :first),
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
       error -> error
@@ -167,7 +167,7 @@ end
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(token, full_claims)
 end
 ```

--- a/sk/lessons/basics/control-structures.md
+++ b/sk/lessons/basics/control-structures.md
@@ -154,7 +154,7 @@ Teraz máme väčší príklad bez `with/1` a potom sa pozrieme ako ho môžeme 
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
       error -> error
@@ -167,7 +167,7 @@ Keď zavedieme `with/1`, dostaneme kód, ktorý je ľahšie pochopiteľný, čit
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(token, full_claims)
 end
 ```

--- a/tr/lessons/basics/control-structures.md
+++ b/tr/lessons/basics/control-structures.md
@@ -161,7 +161,7 @@ Simdi de `with/1` olmayan daha buyuk bir kod ornegini inceleyip, nasil daha iyi 
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
       error -> error
@@ -174,7 +174,7 @@ Yukaridaki kodu `with/1` ile yazdigimizda daha kisa, basit ve kolay anlasilir bi
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token) do
+     {:ok, token, full_claims} <- Guardian.encode_and_sign(user, :token, claims) do
   important_stuff(token, full_claims)
 end
 ```

--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -155,7 +155,7 @@ Chúng ta xem qua về một ví dụ không dùng `with` và sau đó là cách
 ```elixir
 case Repo.insert(changeset) do
   {:ok, user} ->
-    case Guardian.encode_and_sign(resource, :token, claims) do
+    case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, jwt, full_claims} ->
         important_stuff(jwt, full_claims)
       error -> error
@@ -168,7 +168,7 @@ Khi chúng ta dùng `with`, code sẽ dễ đọc hơn và có ít dòng hơn:
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),
-     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token, claims),
      do: important_stuff(jwt, full_claims)
 ```
 


### PR DESCRIPTION
Fixes #1224.

I updated all the existing examples (14 occurrences). Hopefully, the PR is good :)

Languages affected:

* `bg`
* `bn`
* `de`
* `en`
* `gr`
* `id`
* `jp`
* `ko`
* `no`
* `pl`
* `ru`
* `sk`
* `tr`
* `vi`