### PR TITLE
Formatting the code with the Elixir format tool

### DIFF
--- a/en/lessons/advanced/behaviours.md
+++ b/en/lessons/advanced/behaviours.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Behaviours
 redirect_from:
   - /lessons/advanced/behaviours/

--- a/en/lessons/advanced/behaviours.md
+++ b/en/lessons/advanced/behaviours.md
@@ -27,7 +27,9 @@ In order to accomplish this, we'll use the `@callback` directive with syntax sim
 ```elixir
 defmodule Example.Worker do
   @callback init(state :: term) :: {:ok, new_state :: term} | {:error, reason :: term}
-  @callback perform(args :: term, state :: term) :: {:ok, result :: term, new_state :: term} | {:error, reason :: term, new_state :: term}
+  @callback perform(args :: term, state :: term) ::
+              {:ok, result :: term, new_state :: term}
+              | {:error, reason :: term, new_state :: term}
 end
 ```
 
@@ -47,16 +49,17 @@ defmodule Example.Downloader do
 
   def perform(url, opts) do
     url
-    |> HTTPoison.get!
+    |> HTTPoison.get!()
     |> Map.fetch(:body)
     |> write_file(opts[:path])
     |> respond(opts)
   end
 
   defp write_file(:error, _), do: {:error, :missing_body}
+
   defp write_file({:ok, contents}, path) do
     path
-    |> Path.expand
+    |> Path.expand()
     |> File.write(contents)
   end
 

--- a/en/lessons/advanced/concurrency.md
+++ b/en/lessons/advanced/concurrency.md
@@ -47,7 +47,7 @@ To communicate, processes rely on message passing. There are two main components
 defmodule Example do
   def listen do
     receive do
-      {:ok, "hello"} -> IO.puts "World"
+      {:ok, "hello"} -> IO.puts("World")
     end
 
     listen
@@ -88,12 +88,13 @@ Sometimes we don't want our linked process to crash the current one.  For that w
 ```elixir
 defmodule Example do
   def explode, do: exit(:kaboom)
+
   def run do
     Process.flag(:trap_exit, true)
     spawn_link(Example, :explode, [])
 
     receive do
-      {:EXIT, from_pid, reason} -> IO.puts "Exit reason: #{reason}"
+      {:EXIT, from_pid, reason} -> IO.puts("Exit reason: #{reason}")
     end
   end
 end
@@ -110,11 +111,12 @@ What if we don't want to link two processes but still be kept informed? For that
 ```elixir
 defmodule Example do
   def explode, do: exit(:kaboom)
+
   def run do
     {pid, ref} = spawn_monitor(Example, :explode, [])
 
     receive do
-      {:DOWN, ref, :process, from_pid, reason} -> IO.puts "Exit reason: #{reason}"
+      {:DOWN, ref, :process, from_pid, reason} -> IO.puts("Exit reason: #{reason}")
     end
   end
 end

--- a/en/lessons/advanced/concurrency.md
+++ b/en/lessons/advanced/concurrency.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Concurrency
 redirect_from:
   - /lessons/advanced/concurrency/

--- a/en/lessons/advanced/erlang.md
+++ b/en/lessons/advanced/erlang.md
@@ -19,8 +19,8 @@ Let's use `:timer.tc` to time execution of a given function:
 defmodule Example do
   def timed(fun, args) do
     {time, result} = :timer.tc(fun, args)
-    IO.puts "Time: #{time} μs"
-    IO.puts "Result: #{result}"
+    IO.puts("Time: #{time} μs")
+    IO.puts("Result: #{result}")
   end
 end
 
@@ -44,10 +44,8 @@ end
 Now we can access our Erlang library:
 
 ```elixir
-png = :png.create(%{:size => {30, 30},
-                    :mode => {:indexed, 8},
-                    :file => file,
-                    :palette => palette})
+png =
+  :png.create(%{:size => {30, 30}, :mode => {:indexed, 8}, :file => file, :palette => palette})
 ```
 
 ## Notable Differences

--- a/en/lessons/advanced/erlang.md
+++ b/en/lessons/advanced/erlang.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Erlang Interoperability
 redirect_from:
   - /lessons/advanced/erlang/

--- a/en/lessons/advanced/error-handling.md
+++ b/en/lessons/advanced/error-handling.md
@@ -47,10 +47,10 @@ It's possible to match multiple errors in a single rescue:
 try do
   opts
   |> Keyword.fetch!(:source_file)
-  |> File.read!
+  |> File.read!()
 rescue
-  e in KeyError -> IO.puts "missing :source_file option"
-  e in File.Error -> IO.puts "unable to read source file"
+  e in KeyError -> IO.puts("missing :source_file option")
+  e in File.Error -> IO.puts("unable to read source file")
 end
 ```
 
@@ -74,11 +74,12 @@ The end!
 This is most commonly used with files or connections that should be closed:
 
 ```elixir
-{:ok, file} = File.open "example.json"
+{:ok, file} = File.open("example.json")
+
 try do
-   # Do hazardous work
+  # Do hazardous work
 after
-   File.close(file)
+  File.close(file)
 end
 ```
 

--- a/en/lessons/advanced/error-handling.md
+++ b/en/lessons/advanced/error-handling.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Error Handling
 redirect_from:
 - /lessons/advanced/error-handling/

--- a/en/lessons/advanced/escripts.md
+++ b/en/lessons/advanced/escripts.md
@@ -28,9 +28,7 @@ Next we need to update our Mixfile to include the `:escript` option for our proj
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app,
-     version: "0.0.1",
-     escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript]
   end
 
   def escript do
@@ -49,7 +47,7 @@ defmodule ExampleApp.CLI do
     args
     |> parse_args
     |> response
-    |> IO.puts
+    |> IO.puts()
   end
 
   defp parse_args(args) do

--- a/en/lessons/advanced/escripts.md
+++ b/en/lessons/advanced/escripts.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Executables
 redirect_from:
   - /lessons/advanced/escripts/

--- a/en/lessons/advanced/gen-stage.md
+++ b/en/lessons/advanced/gen-stage.md
@@ -57,11 +57,11 @@ $ cd genstage_example
 Let's update our dependencies in `mix.exs` to include `gen_stage`:
 
 ```elixir
-  defp deps do
-    [
-      {:gen_stage, "~> 0.11"},
-    ]
-  end
+defp deps do
+  [
+    {:gen_stage, "~> 0.11"},
+  ]
+end
 ```
 
 We should fetch our dependencies and compile before going much further:
@@ -94,8 +94,8 @@ defmodule GenstageExample.Producer do
   def init(counter), do: {:producer, counter}
 
   def handle_demand(demand, state) do
-    events = Enum.to_list(state..state + demand - 1)
-    {:noreply, events, (state + demand)}
+    events = Enum.to_list(state..(state + demand - 1))
+    {:noreply, events, state + demand}
   end
 end
 ```
@@ -115,7 +115,7 @@ $ touch lib/genstage_example/producer_consumer.ex
 Let's update our file to look like the example code:
 
 ```elixir
-defmodule GenstageExample.ProducerConsumer  do
+defmodule GenstageExample.ProducerConsumer do
   use GenStage
 
   require Integer
@@ -166,7 +166,7 @@ defmodule GenstageExample.Consumer do
 
   def handle_events(events, _from, state) do
     for event <- events do
-      IO.inspect {self(), event, state}
+      IO.inspect({self(), event, state})
     end
 
     # As a consumer we never emit events
@@ -190,7 +190,7 @@ def start(_type, _args) do
   children = [
     worker(GenstageExample.Producer, [0]),
     worker(GenstageExample.ProducerConsumer, []),
-    worker(GenstageExample.Consumer, []),
+    worker(GenstageExample.Consumer, [])
   ]
 
   opts = [strategy: :one_for_one, name: GenstageExample.Supervisor]
@@ -226,7 +226,7 @@ children = [
   worker(GenstageExample.Producer, [0]),
   worker(GenstageExample.ProducerConsumer, []),
   worker(GenstageExample.Consumer, [], id: 1),
-  worker(GenstageExample.Consumer, [], id: 2),
+  worker(GenstageExample.Consumer, [], id: 2)
 ]
 ```
 

--- a/en/lessons/advanced/gen-stage.md
+++ b/en/lessons/advanced/gen-stage.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: GenStage
 redirect_from:
   - /lessons/advanced/gen-stage/

--- a/en/lessons/advanced/metaprogramming.md
+++ b/en/lessons/advanced/metaprogramming.md
@@ -150,9 +150,11 @@ defmodule OurMacro do
 end
 
 require OurMacro
-quoted = quote do
-  OurMacro.unless true, do: "Hi"
-end
+
+quoted =
+  quote do
+    OurMacro.unless(true, do: "Hi")
+  end
 ```
 
 ```elixir
@@ -244,8 +246,8 @@ To see the benefit of `bind_quote` and to demonstrate the revaluation issue let'
 defmodule Example do
   defmacro double_puts(expr) do
     quote do
-      IO.puts unquote(expr)
-      IO.puts unquote(expr)
+      IO.puts(unquote(expr))
+      IO.puts(unquote(expr))
     end
   end
 end
@@ -265,8 +267,8 @@ The times are different!  What happened?  Using `unquote/1` on the same expressi
 defmodule Example do
   defmacro double_puts(expr) do
     quote bind_quoted: [expr: expr] do
-      IO.puts expr
-      IO.puts expr
+      IO.puts(expr)
+      IO.puts(expr)
     end
   end
 end

--- a/en/lessons/advanced/metaprogramming.md
+++ b/en/lessons/advanced/metaprogramming.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Metaprogramming
 redirect_from:
   - /lessons/advanced/metaprogramming/

--- a/en/lessons/advanced/otp-concurrency.md
+++ b/en/lessons/advanced/otp-concurrency.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: OTP Concurrency
 redirect_from:
   - /lessons/advanced/otp-concurrency/

--- a/en/lessons/advanced/otp-concurrency.md
+++ b/en/lessons/advanced/otp-concurrency.md
@@ -59,9 +59,10 @@ defmodule SimpleQueue do
   @doc """
   GenServer.handle_call/3 callback
   """
-  def handle_call(:dequeue, _from, [value|state]) do
+  def handle_call(:dequeue, _from, [value | state]) do
     {:reply, value, state}
   end
+
   def handle_call(:dequeue, _from, []), do: {:reply, nil, []}
 
   def handle_call(:queue, _from, state), do: {:reply, state, state}
@@ -110,9 +111,10 @@ defmodule SimpleQueue do
   @doc """
   GenServer.handle_call/3 callback
   """
-  def handle_call(:dequeue, _from, [value|state]) do
+  def handle_call(:dequeue, _from, [value | state]) do
     {:reply, value, state}
   end
+
   def handle_call(:dequeue, _from, []), do: {:reply, nil, []}
 
   def handle_call(:queue, _from, state), do: {:reply, state, state}
@@ -129,6 +131,7 @@ defmodule SimpleQueue do
   def start_link(state \\ []) do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
+
   def queue, do: GenServer.call(__MODULE__, :queue)
   def enqueue(value), do: GenServer.cast(__MODULE__, {:enqueue, value})
   def dequeue, do: GenServer.call(__MODULE__, :dequeue)

--- a/en/lessons/advanced/otp-supervisors.md
+++ b/en/lessons/advanced/otp-supervisors.md
@@ -21,7 +21,7 @@ Using the SimpleQueue from the [OTP Concurrency](../../advanced/otp-concurrency)
 import Supervisor.Spec
 
 children = [
-  worker(SimpleQueue, [], [name: SimpleQueue])
+  worker(SimpleQueue, [], name: SimpleQueue)
 ]
 
 {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
@@ -80,7 +80,7 @@ Including the `Task.Supervisor` is no different than other supervisors:
 import Supervisor.Spec
 
 children = [
-  supervisor(Task.Supervisor, [[name: ExampleApp.TaskSupervisor, restart: :transient]]),
+  supervisor(Task.Supervisor, [[name: ExampleApp.TaskSupervisor, restart: :transient]])
 ]
 
 {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)

--- a/en/lessons/advanced/otp-supervisors.md
+++ b/en/lessons/advanced/otp-supervisors.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: OTP Supervisors
 redirect_from:
   - /lessons/advanced/otp-supervisors/

--- a/en/lessons/advanced/protocols.md
+++ b/en/lessons/advanced/protocols.md
@@ -51,7 +51,7 @@ defimpl String.Chars, for: Tuple do
   def to_string(tuple) do
     interior =
       tuple
-      |> Tuple.to_list
+      |> Tuple.to_list()
       |> Enum.map(&Kernel.to_string/1)
       |> Enum.join(", ")
 

--- a/en/lessons/advanced/protocols.md
+++ b/en/lessons/advanced/protocols.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Protocols
 redirect_from:
   - /lessons/advanced/protocols/

--- a/en/lessons/advanced/typespec.md
+++ b/en/lessons/advanced/typespec.md
@@ -26,9 +26,9 @@ Let's take a look at example:
 ```elixir
 @spec sum_product(integer) :: integer
 def sum_product(a) do
-    [1, 2, 3]
-    |> Enum.map(fn el -> el * a end)
-    |> Enum.sum
+  [1, 2, 3]
+  |> Enum.map(fn el -> el * a end)
+  |> Enum.sum()
 end
 ```
 
@@ -47,12 +47,12 @@ Let's modify our `sum_times` function and introduce some extra params:
 ```elixir
 @spec sum_times(integer, %Examples{first: integer, last: integer}) :: integer
 def sum_times(a, params) do
-    for i <- params.first..params.last do
-        i
-    end
-       |> Enum.map(fn el -> el * a end)
-       |> Enum.sum
-       |> round
+  for i <- params.first..params.last do
+    i
+  end
+  |> Enum.map(fn el -> el * a end)
+  |> Enum.sum()
+  |> round
 end
 ```
 
@@ -68,13 +68,11 @@ Let define our type:
 
 ```elixir
 defmodule Examples do
+  defstruct first: nil, last: nil
 
-    defstruct first: nil, last: nil
+  @type t(first, last) :: %Examples{first: first, last: last}
 
-    @type t(first, last) :: %Examples{first: first, last: last}
-
-    @type t :: %Examples{first: integer, last: integer}
-
+  @type t :: %Examples{first: integer, last: integer}
 end
 ```
 
@@ -83,14 +81,14 @@ We defined the type `t(first, last)` already, which is a representation of the s
 What is a difference? First one represents the struct `Examples` of which the two keys could be any type. Second one represents struct which keys are `integers`. That means code like this:
 
 ```elixir
-@spec sum_times(integer, Examples.t) :: integer
+@spec sum_times(integer, Examples.t()) :: integer
 def sum_times(a, params) do
-    for i <- params.first..params.last do
-        i
-    end
-       |> Enum.map(fn el -> el * a end)
-       |> Enum.sum
-       |> round
+  for i <- params.first..params.last do
+    i
+  end
+  |> Enum.map(fn el -> el * a end)
+  |> Enum.sum()
+  |> round
 end
 ```
 
@@ -99,12 +97,12 @@ Is equal to code like:
 ```elixir
 @spec sum_times(integer, Examples.t(integer, integer)) :: integer
 def sum_times(a, params) do
-    for i <- params.first..params.last do
-        i
-    end
-       |> Enum.map(fn el -> el * a end)
-       |> Enum.sum
-       |> round
+  for i <- params.first..params.last do
+    i
+  end
+  |> Enum.map(fn el -> el * a end)
+  |> Enum.sum()
+  |> round
 end
 ```
 
@@ -114,12 +112,10 @@ The last element that we need to talk about is how to document our types. As we 
 
 ```elixir
 defmodule Examples do
-
-    @typedoc """
-        Type that represents Examples struct with :first as integer and :last as integer.
-    """
-    @type t :: %Examples{first: integer, last: integer}
-
+  @typedoc """
+      Type that represents Examples struct with :first as integer and :last as integer.
+  """
+  @type t :: %Examples{first: integer, last: integer}
 end
 ```
 

--- a/en/lessons/advanced/typespec.md
+++ b/en/lessons/advanced/typespec.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Specifications and types
 redirect_from:
   - /lessons/advanced/typespec/

--- a/en/lessons/advanced/umbrella-projects.md
+++ b/en/lessons/advanced/umbrella-projects.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Umbrella Projects
 redirect_from:
   - /lessons/advanced/umbrella-projects/

--- a/en/lessons/advanced/umbrella-projects.md
+++ b/en/lessons/advanced/umbrella-projects.md
@@ -186,7 +186,7 @@ You may think that interacting with the apps would be a little different in an u
 ```elixir
 defmodule Datasets do
   def hello do
-    IO.puts "Hello, I'm the datasets"
+    IO.puts("Hello, I'm the datasets")
   end
 end
 ```

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Control Structures
 redirect_from:
   - /lessons/basics/control-structures/

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -160,9 +160,13 @@ case Repo.insert(changeset) do
     case Guardian.encode_and_sign(user, :token, claims) do
       {:ok, token, full_claims} ->
         important_stuff(token, full_claims)
-      error -> error
+
+      error ->
+        error
     end
-  error -> error
+
+  error ->
+    error
 end
 ```
 
@@ -185,15 +189,16 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
-      IO.puts "#{number} divided by 2 is #{div(number, 2)}"
-      :even
+       true <- Integer.is_even(number) do
+    IO.puts("#{number} divided by 2 is #{div(number, 2)}")
+    :even
   else
     :error ->
-      IO.puts "We don't have this item in map"
+      IO.puts("We don't have this item in map")
       :error
+
     _ ->
-      IO.puts "It is odd"
+      IO.puts("It is odd")
       :odd
   end
 ```

--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -27,7 +27,7 @@ Take this Elixir Script (greeting.exs):
 
 ```elixir
 # Outputs 'Hello, chum.' to the console.
-IO.puts "Hello, " <> "chum."
+IO.puts("Hello, " <> "chum.")
 ```
 
 Elixir, when running this script will ignore everything from `#` to the end of the line, treating it as throwaway data. It may add no value to the operation or performance of the script, however when it's not so obvious what is happening a programmer should know from reading your comment. Be mindful not to abuse the single line comment! Littering a codebase could become an unwelcome nightmare for some. It is best used in moderation.
@@ -87,7 +87,7 @@ defmodule Greeter do
       "Hello, pete"
 
   """
-  @spec hello(String.t) :: String.t
+  @spec hello(String.t()) :: String.t()
   def hello(name) do
     "Hello, " <> name
   end
@@ -249,7 +249,7 @@ defmodule Greeter do
   """
 
   def hello(name) do
-    IO.puts "Hello, " <> name
+    IO.puts("Hello, " <> name)
   end
 end
 ```
@@ -268,7 +268,7 @@ defmodule Greeter do
   # and so on...
 
   def hello(name) do
-    IO.puts "Hello, " <> name
+    IO.puts("Hello, " <> name)
   end
 end
 ```
@@ -297,7 +297,7 @@ defmodule Greeter do
       "Hello, pete"
 
   """
-  @spec hello(String.t) :: String.t
+  @spec hello(String.t()) :: String.t()
   def hello(name) do
     "Hello, " <> name
   end

--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Documentation
 redirect_from:
   - /lessons/basics/documentation/

--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Functions
 redirect_from:
   - /lessons/basics/functions/

--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -219,6 +219,7 @@ Elixir doesn't like default arguments in multiple matching functions, it can be 
 ```elixir
 defmodule Greeter do
   def hello(names, language_code \\ "en")
+
   def hello(names, language_code) when is_list(names) do
     names
     |> Enum.join(", ")

--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Custom Mix Tasks
 redirect_from:
   - /lessons/basics/mix-tasks/

--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -60,12 +60,11 @@ Now, in our **lib/hello.ex** file that Mix generated for us, let's create a simp
 
 ```elixir
 defmodule Hello do
-
   @doc """
   Output's `Hello, World!` everytime.
   """
   def say do
-    IO.puts "Hello, World!"
+    IO.puts("Hello, World!")
   end
 end
 ```
@@ -80,7 +79,8 @@ defmodule Mix.Tasks.Hello do
 
   @shortdoc "Simply runs the Hello.say/0 command."
   def run(_) do
-    Hello.say # calling our Hello.say() function from earlier
+    # calling our Hello.say() function from earlier
+    Hello.say()
   end
 end
 ```

--- a/en/lessons/basics/mix.md
+++ b/en/lessons/basics/mix.md
@@ -45,7 +45,7 @@ defmodule Example.Mixfile do
       app: :example,
       version: "0.1.0",
       elixir: "~> 1.5",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end
@@ -57,9 +57,7 @@ defmodule Example.Mixfile do
   end
 
   defp deps do
-    [
-
-    ]
+    []
   end
 end
 ```
@@ -107,10 +105,12 @@ For this example let's look at a project with dependencies, like [phoenix_slim](
 
 ```elixir
 def deps do
-  [{:phoenix, "~> 1.1 or ~> 1.2"},
-   {:phoenix_html, "~> 2.3"},
-   {:cowboy, "~> 1.0", only: [:dev, :test]},
-   {:slime, "~> 0.14"}]
+  [
+    {:phoenix, "~> 1.1 or ~> 1.2"},
+    {:phoenix_html, "~> 2.3"},
+    {:cowboy, "~> 1.0", only: [:dev, :test]},
+    {:slime, "~> 0.14"}
+  ]
 end
 ```
 

--- a/en/lessons/basics/mix.md
+++ b/en/lessons/basics/mix.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Mix
 redirect_from:
   - /lessons/basics/mix/

--- a/en/lessons/basics/strings.md
+++ b/en/lessons/basics/strings.md
@@ -123,9 +123,9 @@ defmodule Anagram do
 
   def sort_string(string) do
     string
-    |> String.downcase
-    |> String.graphemes
-    |> Enum.sort
+    |> String.downcase()
+    |> String.graphemes()
+    |> Enum.sort()
   end
 end
 ```

--- a/en/lessons/basics/strings.md
+++ b/en/lessons/basics/strings.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Strings
 redirect_from:
   - /lessons/basics/strings/

--- a/en/lessons/basics/testing.md
+++ b/en/lessons/basics/testing.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Testing
 redirect_from:
   - /lessons/basics/testing/

--- a/en/lessons/basics/testing.md
+++ b/en/lessons/basics/testing.md
@@ -110,7 +110,7 @@ In Elixir, applications consist of actors/processes that send messages to each o
 ```elixir
 defmodule SendingProcess do
   def run(pid) do
-    send pid, :ping
+    send(pid, :ping)
   end
 end
 
@@ -136,7 +136,7 @@ defmodule OutputTest do
   import ExUnit.CaptureIO
 
   test "outputs Hello World" do
-    assert capture_io(fn -> IO.puts "Hello World" end) == "Hello World\n"
+    assert capture_io(fn -> IO.puts("Hello World") end) == "Hello World\n"
   end
 end
 ```

--- a/en/lessons/libraries/benchee.md
+++ b/en/lessons/libraries/benchee.md
@@ -35,11 +35,11 @@ The first command will download and install Benchee. You may be asked to install
 
 ```elixir
 list = Enum.to_list(1..10_000)
-map_fun = fn(i) -> [i, i * i] end
+map_fun = fn i -> [i, i * i] end
 
 Benchee.run(%{
   "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-  "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
+  "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
 })
 ```
 
@@ -142,28 +142,32 @@ So, let's look at our original example again:
 
 ```elixir
 list = Enum.to_list(1..10_000)
-map_fun = fn(i) -> [i, i * i] end
+map_fun = fn i -> [i, i * i] end
 
 Benchee.run(%{
   "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-  "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
+  "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
 })
 ```
 
 In that example we're only using a single list of the integers from 1 to 10,000. Let's update that to use a couple different inputs so we can see what happens with smaller and larger lists. So, open that file, and we're going to change it to look like this:
 
 ```elixir
-map_fun = fn(i) -> [i, i * i] end
+map_fun = fn i -> [i, i * i] end
+
 inputs = %{
   "small list" => Enum.to_list(1..100),
   "medium list" => Enum.to_list(1..10_000),
   "large list" => Enum.to_list(1..1_000_000)
 }
 
-Benchee.run(%{
-  "flat_map"    => fn(list) -> Enum.flat_map(list, map_fun) end,
-  "map.flatten" => fn(list) -> list |> Enum.map(map_fun) |> List.flatten end
-}, inputs: inputs)
+Benchee.run(
+  %{
+    "flat_map" => fn list -> Enum.flat_map(list, map_fun) end,
+    "map.flatten" => fn list -> list |> Enum.map(map_fun) |> List.flatten() end
+  },
+  inputs: inputs
+)
 ```
 
 You'll notice two differences. First, we now have an `inputs` map that contains the information for our inputs to our functions. We're passing that inputs map as a configuration option to `Benchee.run/2`.
@@ -175,7 +179,7 @@ fn -> Enum.flat_map(list, map_fun) end
 
 we now have:
 ```elixir
-fn(list) -> Enum.flat_map(list, map_fun) end
+fn list -> Enum.flat_map(list, map_fun) end
 ```
 
 Let's run this again using:
@@ -266,9 +270,9 @@ them as dependencies to your `mix.exs` file like so:
 ```elixir
 defp deps do
   [
-    {:benchee_csv,  "~> 0.6", only: :dev},
+    {:benchee_csv, "~> 0.6", only: :dev},
     {:benchee_json, "~> 0.3", only: :dev},
-    {:benchee_html, "~> 0.3", only: :dev},
+    {:benchee_html, "~> 0.3", only: :dev}
   ]
 end
 ```
@@ -286,13 +290,13 @@ defmodule Custom.Formatter do
   def output(suite) do
     suite
     |> format
-    |> IO.write
+    |> IO.write()
 
     suite
   end
 
   defp format(suite) do
-    Enum.map_join(suite.scenarios, "\n", fn(scenario) ->
+    Enum.map_join(suite.scenarios, "\n", fn scenario ->
       "Average for #{scenario.job_name}: #{scenario.run_time_statistics.average}"
     end)
   end
@@ -303,12 +307,15 @@ And then we could run our benchmark like this:
 
 ```elixir
 list = Enum.to_list(1..10_000)
-map_fun = fn(i) -> [i, i * i] end
+map_fun = fn i -> [i, i * i] end
 
-Benchee.run(%{
-  "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-  "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
-}, formatters: [&Custom.Formatter.output/1])
+Benchee.run(
+  %{
+    "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+    "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+  },
+  formatters: [&Custom.Formatter.output/1]
+)
 ```
 
 And when we run now with our custom formatter, we would see:

--- a/en/lessons/libraries/benchee.md
+++ b/en/lessons/libraries/benchee.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Benchee
 redirect_from:
   - /lessons/libraries/benchee/

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Guardian (Basics)
 redirect_from:
   - /lessons/libraries/guardian/

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -83,9 +83,10 @@ end
 `config/config.ex`
 
 ```elixir
+# in each environment config file you should overwrite this if it's external
 config :guardian, Guardian,
   issuer: "MyAppId",
-  secret_key: Mix.env, # in each environment config file you should overwrite this if it's external
+  secret_key: Mix.env(),
   serializer: MyApp.GuardianSerializer
 ```
 
@@ -100,11 +101,11 @@ defmodule MyApp.GuardianSerializer do
   alias MyApp.Repo
   alias MyApp.User
 
-  def for_token(user = %User{}), do: { :ok, "User:#{user.id}" }
-  def for_token(_), do: { :error, "Unknown resource type" }
+  def for_token(user = %User{}), do: {:ok, "User:#{user.id}"}
+  def for_token(_), do: {:error, "Unknown resource type"}
 
-  def from_token("User:" <> id), do: { :ok, Repo.get(User, id) }
-  def from_token(_), do: { :error, "Unknown resource type" }
+  def from_token("User:" <> id), do: {:ok, Repo.get(User, id)}
+  def from_token(_), do: {:error, "Unknown resource type"}
 end
 ```
 Your serializer is responsible for finding the resource identified in the `sub` (subject) field. This could be a lookup from a db, an API, or even a simple string.
@@ -134,13 +135,13 @@ Let's create some pipelines.
 
 ```elixir
 pipeline :maybe_browser_auth do
-  plug Guardian.Plug.VerifySession
-  plug Guardian.Plug.VerifyHeader, realm: "Bearer"
-  plug Guardian.Plug.LoadResource
+  plug(Guardian.Plug.VerifySession)
+  plug(Guardian.Plug.VerifyHeader, realm: "Bearer")
+  plug(Guardian.Plug.LoadResource)
 end
 
 pipeline :ensure_authed_access do
-  plug Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler}
+  plug(Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler})
 end
 ```
 
@@ -150,17 +151,17 @@ The second pipeline requires that there is a valid, verified token present and t
 
 ```elixir
 scope "/", MyApp do
-  pipe_through [:browser, :maybe_browser_auth]
+  pipe_through([:browser, :maybe_browser_auth])
 
-  get "/login", LoginController, :new
-  post "/login", LoginController, :create
-  delete "/login", LoginController, :delete
+  get("/login", LoginController, :new)
+  post("/login", LoginController, :create)
+  delete("/login", LoginController, :delete)
 end
 
 scope "/", MyApp do
-  pipe_through [:browser, :maybe_browser_auth, :ensure_authed_access]
+  pipe_through([:browser, :maybe_browser_auth, :ensure_authed_access])
 
-  resource "/protected/things", ProtectedController
+  resource("/protected/things", ProtectedController)
 end
 ```
 
@@ -215,10 +216,13 @@ Logging in and out of a browser session is very simple. In your login controller
 def create(conn, params) do
   case find_the_user_and_verify_them_from_params(params) do
     {:ok, user} ->
+      # Use access tokens. Other tokens can be used, like :refresh etc
       conn
-      |> Guardian.Plug.sign_in(user, :access) # Use access tokens. Other tokens can be used, like :refresh etc
+      |> Guardian.Plug.sign_in(user, :access)
       |> respond_somehow()
+
     {:error, reason} ->
+      nil
       # handle not verifying the user's credentials
   end
 end
@@ -238,8 +242,8 @@ def create(conn, params) do
   case find_the_user_and_verify_them_from_params(params) do
     {:ok, user} ->
       {:ok, jwt, _claims} = Guardian.encode_and_sign(user, :access)
-      conn
-      |> respond_somehow({token: jwt})
+      conn |> respond_somehow(%{token: jwt})
+
     {:error, reason} ->
       # handle not verifying the user's credentials
   end

--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -63,10 +63,12 @@ defmodule PoolboyApp.Application do
   use Application
 
   defp poolboy_config do
-    [{:name, {:local, :worker}},
+    [
+      {:name, {:local, :worker}},
       {:worker_module, PoolboyApp.Worker},
       {:size, 5},
-      {:max_overflow, 2}]
+      {:max_overflow, 2}
+    ]
   end
 
   def start(_type, _args) do
@@ -100,7 +102,7 @@ defmodule PoolboyApp.Worker do
   end
 
   def handle_call({:square_root, x}, _from, state) do
-    IO.puts "process #{inspect self()} calculating square root of #{x}"
+    IO.puts("process #{inspect(self())} calculating square root of #{x}")
     :timer.sleep(1000)
     {:reply, :math.sqrt(x), state}
   end
@@ -117,13 +119,17 @@ defmodule PoolboyApp.Test do
 
   def start do
     1..20
-    |> Enum.map(fn(i) -> async_call_square_root(i) end)
-    |> Enum.each(fn(task) -> await_and_inspect(task) end)
+    |> Enum.map(fn i -> async_call_square_root(i) end)
+    |> Enum.each(fn task -> await_and_inspect(task) end)
   end
 
   defp async_call_square_root(i) do
     Task.async(fn ->
-      :poolboy.transaction(:worker, fn(pid) -> GenServer.call(pid, {:square_root, i}) end, @timeout)
+      :poolboy.transaction(
+        :worker,
+        fn pid -> GenServer.call(pid, {:square_root, i}) end,
+        @timeout
+      )
     end)
   end
 

--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Poolboy
 redirect_from:
   - /lessons/libraries/poolboy/

--- a/en/lessons/specifics/debugging.md
+++ b/en/lessons/specifics/debugging.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Debugging
 redirect_from:
   - /lessons/specifics/debugging/

--- a/en/lessons/specifics/debugging.md
+++ b/en/lessons/specifics/debugging.md
@@ -65,10 +65,10 @@ Since `number` is not `integer` we get an error. How do we fix it? We need to us
 ```elixir
 @spec sum_times(integer) :: integer
 def sum_times(a) do
-    [1, 2, 3]
-    |> Enum.map(fn el -> el * a end)
-    |> Enum.sum
-    |> round
+  [1, 2, 3]
+  |> Enum.map(fn el -> el * a end)
+  |> Enum.sum()
+  |> round
 end
 ```
 
@@ -91,7 +91,6 @@ Let’s look at a basic module:
 
 ```elixir
 defmodule Example do
-
   def cpu_burns(a, b, c) do
     x = a * 2
     y = b * 3
@@ -99,7 +98,6 @@ defmodule Example do
 
     x + y + z
   end
-
 end
 ```
 

--- a/en/lessons/specifics/ecto.md
+++ b/en/lessons/specifics/ecto.md
@@ -15,8 +15,7 @@ To get started we need to include Ecto and a database adapter in our project's `
 
 ```elixir
 defp deps do
-  [{:ecto, "~> 2.2"},
-   {:postgrex, ">= 0.0.0"}]
+  [{:ecto, "~> 2.2"}, {:postgrex, ">= 0.0.0"}]
 end
 ```
 
@@ -34,8 +33,7 @@ Finally we need to create our project's repository, the database wrapper.  This 
 
 ```elixir
 defmodule ExampleApp.Repo do
-  use Ecto.Repo,
-    otp_app: :example_app
+  use Ecto.Repo, otp_app: :example_app
 end
 ```
 
@@ -102,15 +100,15 @@ defmodule ExampleApp.Repo.Migrations.CreateUser do
 
   def change do
     create table(:users) do
-      add :username, :string, unique: true
-      add :encrypted_password, :string, null: false
-      add :email, :string
-      add :confirmed, :boolean, default: false
+      add(:username, :string, unique: true)
+      add(:encrypted_password, :string, null: false)
+      add(:email, :string)
+      add(:confirmed, :boolean, default: false)
 
       timestamps
     end
 
-    create unique_index(:users, [:username], name: :unique_usernames)
+    create(unique_index(:users, [:username], name: :unique_usernames))
   end
 end
 ```
@@ -135,12 +133,12 @@ defmodule ExampleApp.User do
   import Ecto.Changeset
 
   schema "users" do
-    field :username, :string
-    field :encrypted_password, :string
-    field :email, :string
-    field :confirmed, :boolean, default: false
-    field :password, :string, virtual: true
-    field :password_confirmation, :string, virtual: true
+    field(:username, :string)
+    field(:encrypted_password, :string)
+    field(:email, :string)
+    field(:confirmed, :boolean, default: false)
+    field(:password, :string, virtual: true)
+    field(:password_confirmation, :string, virtual: true)
 
     timestamps
   end
@@ -173,11 +171,14 @@ The official documentation can be found at [Ecto.Query](http://hexdocs.pm/ecto/E
 Ecto provides an excellent Query DSL that allows us to express queries clearly.  To find the usernames of all confirmed accounts we could use something like this:
 
 ```elixir
-alias ExampleApp.{Repo,User}
+alias ExampleApp.{Repo, User}
 
-query = from u in User,
+query =
+  from(
+    u in User,
     where: u.confirmed == true,
     select: u.username
+  )
 
 Repo.all(query)
 ```
@@ -189,17 +190,23 @@ In addition to `all/2`, Repo provides a number of callbacks including `one/2`, `
 If we want to count the number of users that have confirmed account we could use `count/1`:
 
 ```elixir
-query = from u in User,
+query =
+  from(
+    u in User,
     where: u.confirmed == true,
     select: count(u.id)
+  )
 ```
 
 There is `count/2` function that counts the distinct values in given entry:
 
 ```elixir
-query = from u in User,
+query =
+  from(
+    u in User,
     where: u.confirmed == true,
     select: count(u.id, :distinct)
+  )
 ```
 
 ### Group By
@@ -207,9 +214,12 @@ query = from u in User,
 To group users by their confirmation status we can include the `group_by` option:
 
 ```elixir
-query = from u in User,
+query =
+  from(
+    u in User,
     group_by: u.confirmed,
     select: [u.confirmed, count(u.id)]
+  )
 
 Repo.all(query)
 ```
@@ -219,9 +229,12 @@ Repo.all(query)
 Ordering users by their creation date:
 
 ```elixir
-query = from u in User,
+query =
+  from(
+    u in User,
     order_by: u.inserted_at,
     select: [u.username, u.inserted_at]
+  )
 
 Repo.all(query)
 ```
@@ -229,9 +242,12 @@ Repo.all(query)
 To order by `DESC`:
 
 ```elixir
-query = from u in User,
+query =
+  from(
+    u in User,
     order_by: [desc: u.inserted_at],
     select: [u.username, u.inserted_at]
+  )
 ```
 
 ### Joins
@@ -239,9 +255,12 @@ query = from u in User,
 Assuming we had a profile associated with our user, let's find all confirmed account profiles:
 
 ```elixir
-query = from p in Profile,
+query =
+  from(
+    p in Profile,
     join: u in assoc(p, :user),
     where: u.confirmed == true
+  )
 ```
 
 ### Fragments
@@ -249,9 +268,12 @@ query = from p in Profile,
 Sometimes, like when we need specific database functions, the Query API isn't enough.  The `fragment/1` function exists for this purpose:
 
 ```elixir
-query = from u in User,
-    where: fragment("downcase(?)", u.username) == ^username
+query =
+  from(
+    u in User,
+    where: fragment("downcase(?)", u.username) == ^username,
     select: u
+  )
 ```
 
 Additional query examples can be found in the [Ecto.Query.API](http://hexdocs.pm/ecto/Ecto.Query.API.html) module description.
@@ -271,12 +293,12 @@ defmodule ExampleApp.User do
   import Comeonin.Bcrypt, only: [hashpwsalt: 1]
 
   schema "users" do
-    field :username, :string
-    field :encrypted_password, :string
-    field :email, :string
-    field :confirmed, :boolean, default: false
-    field :password, :string, virtual: true
-    field :password_confirmation, :string, virtual: true
+    field(:username, :string)
+    field(:encrypted_password, :string)
+    field(:email, :string)
+    field(:confirmed, :boolean, default: false)
+    field(:password, :string, virtual: true)
+    field(:password_confirmation, :string, virtual: true)
 
     timestamps
   end
@@ -297,6 +319,7 @@ defmodule ExampleApp.User do
     case get_change(changeset, :password_confirmation) do
       nil ->
         password_incorrect_error(changeset)
+
       confirmation ->
         password = get_field(changeset, :password)
         if confirmation == password, do: changeset, else: password_mismatch_error(changeset)

--- a/en/lessons/specifics/ecto.md
+++ b/en/lessons/specifics/ecto.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Ecto
 redirect_from:
   - /lessons/specifics/ecto/

--- a/en/lessons/specifics/eex.md
+++ b/en/lessons/specifics/eex.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Embedded Elixir (EEx)
 redirect_from:
   - /lessons/specifics/eex/

--- a/en/lessons/specifics/eex.md
+++ b/en/lessons/specifics/eex.md
@@ -34,7 +34,7 @@ Hi, <%= name %>
 
 defmodule Example do
   require EEx
-  EEx.function_from_file :def, :greeting, "greeting.eex", [:name]
+  EEx.function_from_file(:def, :greeting, "greeting.eex", [:name])
 end
 
 iex> Example.greeting("Sean")

--- a/en/lessons/specifics/ets.md
+++ b/en/lessons/specifics/ets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Erlang Term Storage (ETS)
 redirect_from:
   - /lessons/specifics/ets/

--- a/en/lessons/specifics/ets.md
+++ b/en/lessons/specifics/ets.md
@@ -188,7 +188,9 @@ defmodule SimpleCache do
       nil ->
         ttl = Keyword.get(opts, :ttl, 3600)
         cache_apply(mod, fun, args, ttl)
-      result -> result
+
+      result ->
+        result
     end
   end
 

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Plug
 redirect_from:
   - /lessons/specifics/plug/

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -35,7 +35,7 @@ The first thing to do is add both Plug and a web server (we'll be using Cowboy) 
 defp deps do
   [
     {:cowboy, "~> 1.1.2"},
-    {:plug, "~> 1.3.4"},
+    {:plug, "~> 1.3.4"}
   ]
 end
 ```
@@ -91,7 +91,7 @@ defmodule Example do
       Plug.Adapters.Cowboy.child_spec(:http, Example.HelloWorldPlug, [], port: 8080)
     ]
 
-    Logger.info "Started application"
+    Logger.info("Started application")
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end
@@ -141,11 +141,11 @@ To start let's create a file at `lib/example/router.ex` and copy the following i
 defmodule Example.Router do
   use Plug.Router
 
-  plug :match
-  plug :dispatch
+  plug(:match)
+  plug(:dispatch)
 
-  get "/", do: send_resp(conn, 200, "Welcome")
-  match _, do: send_resp(conn, 404, "Oops!")
+  get("/", do: send_resp(conn, 200, "Welcome"))
+  match(_, do: send_resp(conn, 404, "Oops!"))
 end
 ```
 
@@ -161,7 +161,8 @@ def start(_type, _args) do
   children = [
     Plug.Adapters.Cowboy.child_spec(:http, Example.Router, [], port: 8080)
   ]
-  Logger.info "Started application"
+
+  Logger.info("Started application")
   Supervisor.start_link(children, strategy: :one_for_one)
 end
 ```
@@ -190,7 +191,6 @@ We'll create it at `lib/plug/verify_request.ex`:
 
 ```elixir
 defmodule Example.Plug.VerifyRequest do
-
   defmodule IncompleteRequestError do
     @moduledoc """
     Error raised when a required field is missing.
@@ -207,10 +207,12 @@ defmodule Example.Plug.VerifyRequest do
   end
 
   defp verify_request!(body_params, fields) do
-    verified = body_params
-               |> Map.keys
-               |> contains_fields?(fields)
-    unless verified, do: raise IncompleteRequestError
+    verified =
+      body_params
+      |> Map.keys()
+      |> contains_fields?(fields)
+
+    unless verified, do: raise(IncompleteRequestError)
   end
 
   defp contains_fields?(keys, fields), do: Enum.all?(fields, &(&1 in keys))
@@ -239,16 +241,20 @@ defmodule Example.Router do
 
   alias Example.Plug.VerifyRequest
 
-  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
-  plug VerifyRequest, fields: ["content", "mimetype"],
-                      paths:  ["/upload"]
+  plug(Plug.Parsers, parsers: [:urlencoded, :multipart])
 
-  plug :match
-  plug :dispatch
+  plug(
+    VerifyRequest,
+    fields: ["content", "mimetype"],
+    paths: ["/upload"]
+  )
 
-  get "/", do: send_resp(conn, 200, "Welcome\n")
-  post "/upload", do: send_resp(conn, 201, "Uploaded\n")
-  match _, do: send_resp(conn, 404, "Oops!\n")
+  plug(:match)
+  plug(:dispatch)
+
+  get("/", do: send_resp(conn, 200, "Welcome\n"))
+  post("/upload", do: send_resp(conn, 201, "Uploaded\n"))
+  match(_, do: send_resp(conn, 404, "Oops!\n"))
 end
 ```
 
@@ -327,25 +333,28 @@ defmodule Example.RouterTest do
   @opts Router.init([])
 
   test "returns welcome" do
-    conn = conn(:get, "/", "")
-           |> Router.call(@opts)
+    conn =
+      conn(:get, "/", "")
+      |> Router.call(@opts)
 
     assert conn.state == :sent
     assert conn.status == 200
   end
 
   test "returns uploaded" do
-    conn = conn(:post, "/upload", "content=#{@content}&mimetype=#{@mimetype}")
-           |> put_req_header("content-type", "application/x-www-form-urlencoded")
-           |> Router.call(@opts)
+    conn =
+      conn(:post, "/upload", "content=#{@content}&mimetype=#{@mimetype}")
+      |> put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> Router.call(@opts)
 
     assert conn.state == :sent
     assert conn.status == 201
   end
 
   test "returns 404" do
-    conn = conn(:get, "/missing", "")
-           |> Router.call(@opts)
+    conn =
+      conn(:get, "/missing", "")
+      |> Router.call(@opts)
 
     assert conn.state == :sent
     assert conn.status == 404


### PR DESCRIPTION
To celebrate the Elixir formatter I've gone through and formatted the code blocks. The example code will now reflect the formatted Elixir of the future!

I specifically ignored some of the examples because the format was important for teaching purposes and only formatted code blocks and config.

I also found a breaking syntax error in the [Guardian token response example](https://github.com/elixirschool/elixirschool/compare/master...SpyR1014:master#diff-905f78632ecd759996eb649fac036c65R245) where `{token: jwt}` needed to be changed to `%{token: jwt}`.

There was also a broken [ecto example](https://github.com/elixirschool/elixirschool/compare/master...SpyR1014:master#diff-4955bc2f9bc2a2d8f301f1425c2c34feR274) that was missing a comma.

Something very interesting the formatter did was add more parenthesis. This is especially prevalent in the plugs and ecto section.