### PR TITLE
Fix warning in using `else` alongside `with` example code block.

### DIFF
--- a/bn/lessons/basics/control-structures.md
+++ b/bn/lessons/basics/control-structures.md
@@ -183,7 +183,7 @@ import Integer
 m = %{a: 1, c: 3}
 
 a = with {:ok, res} <- Map.fetch(m, :a),
-  true <- Integer.is_even(res) do
+  true <- is_even(res) do
     IO.puts "Divided by 2 it is #{div(res, 2)}"
 else 
   :error -> IO.puts "We don't have this item in map"

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -189,9 +189,9 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-       true <- Integer.is_even(number) do
-    IO.puts("#{number} divided by 2 is #{div(number, 2)}")
-    :even
+    true <- is_even(number) do
+      IO.puts "#{number} divided by 2 is #{div(number, 2)}"
+      :even
   else
     :error ->
       IO.puts("We don't have this item in map")

--- a/gr/lessons/basics/control-structures.md
+++ b/gr/lessons/basics/control-structures.md
@@ -183,7 +183,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
+    true <- is_even(number) do
       IO.puts "#{number} διαιρούμενο με το 2 ισούται με #{div(number, 2)}"
       :even
   else

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -182,7 +182,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, res} <- Map.fetch(m, :a),
-    true <- Integer.is_even(res) do
+    true <- is_even(res) do
       IO.puts "Divided by 2 it is #{div(res, 2)}"
       :even
   else

--- a/pl/lessons/basics/control-structures.md
+++ b/pl/lessons/basics/control-structures.md
@@ -179,7 +179,7 @@ import Integer
 m = %{a: 1, c: 3}
 
 a = with {:ok, res} <- Map.fetch(m, :a),
-  true <- Integer.is_even(res) do
+  true <- is_even(res) do
     IO.puts "Divided by 2 it is #{div(res, 2)}"
 else 
   :error -> IO.puts "We don't have this item in map"

--- a/ru/lessons/basics/control-structures.md
+++ b/ru/lessons/basics/control-structures.md
@@ -181,7 +181,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
+    true <- is_even(number) do
       IO.puts "#{number} divided by 2 is #{div(number, 2)}"
       :even
   else

--- a/sk/lessons/basics/control-structures.md
+++ b/sk/lessons/basics/control-structures.md
@@ -181,7 +181,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
+    true <- is_even(number) do
       IO.puts "#{number} divided by 2 is #{div(number, 2)}"
       :even
   else

--- a/th/lessons/basics/control-structures.md
+++ b/th/lessons/basics/control-structures.md
@@ -184,7 +184,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
+    true <- is_even(number) do
       IO.puts "#{number} divided by 2 is #{div(number, 2)}"
       :even
   else

--- a/tr/lessons/basics/control-structures.md
+++ b/tr/lessons/basics/control-structures.md
@@ -189,7 +189,7 @@ m = %{a: 1, c: 3}
 
 a =
   with {:ok, number} <- Map.fetch(m, :a),
-    true <- Integer.is_even(number) do
+    true <- is_even(number) do
       IO.puts "#{number}, 2 ile bolumu : #{div(number, 2)}"
       :cift
   else

--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -180,7 +180,7 @@ import Integer
 m = %{a: 1, c: 3}
 
 a = with {:ok, res} <- Map.fetch(m, :a),
-  true <- Integer.is_even(res) do
+  true <- is_even(res) do
     IO.puts "Divided by 2 it is #{div(res, 2)}"
 else
   :error -> IO.puts "We don't have this item in map"


### PR DESCRIPTION
The example code block for using `else` with `with` throws a warning for importing `Integer` and not using it; fixed by removing `Integer.is_even` and just calling `is_even` directly.