### PR TITLE
Fix an error in the version definition of pipe-operator lesson

### DIFF
--- a/bg/lessons/basics/pipe-operator.md
+++ b/bg/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: Поточен оператор
 ---
 
@@ -30,14 +30,14 @@ other_function() |> new_function() |> baz() |> bar() |> foo()
 - Разбиване на символи (неопределено)
 
 ```shell
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 
 - Изпиши всички символи с главни букви
 
 ```shell
-iex> "Elixir rocks" |> String.split |> Enum.map( &String.upcase/1 )
+iex> "Elixir rocks" |> String.upcase() |> String.split()
 ["ELIXIR", "ROCKS"]
 ```
 

--- a/de/lessons/basics/pipe-operator.md
+++ b/de/lessons/basics/pipe-operator.md
@@ -30,7 +30,7 @@ Für die folgenden Beispielen wählen wir Elixirs Stringmodul.
 - String trennen
 
 ```elixir
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 

--- a/en/lessons/basics/pipe-operator.md
+++ b/en/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Pipe Operator
 redirect_from:
   - /lessons/basics/pipe-operator/
@@ -32,14 +32,14 @@ For this set of examples, we will use Elixir's String module.
 - Tokenize String (loosely)
 
 ```elixir
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 
 - Uppercase all the tokens
 
 ```elixir
-iex> "Elixir rocks" |> String.upcase |> String.split
+iex> "Elixir rocks" |> String.upcase() |> String.split()
 ["ELIXIR", "ROCKS"]
 ```
 

--- a/es/lessons/basics/pipe-operator.md
+++ b/es/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: Operador Pipe
 ---
 
@@ -31,14 +31,14 @@ Para este grupo de ejemplos, usaremos el módulo String de elixir.
 - Separar Cadenas (Tokenize String)
 
 ```shell
-iex> "Elixir language" |> String.split
+iex> "Elixir language" |> String.split()
 ["Elixir", "language"]
 ```
 
 - Mayúsculas a todos los caracteres (Uppercase all the tokens)
 
 ```shell
-iex> "Elixir language" |> String.split |> Enum.map( &String.upcase/1 )
+iex> "Elixir language" |> String.upcase() |> String.split()
 ["ELIXIR", "LANGUAGE"]
 ```
 

--- a/fr/lessons/basics/pipe-operator.md
+++ b/fr/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: L'opérateur Pipe
 ---
 
@@ -30,14 +30,14 @@ Nous allons utiliser le module String d'Elixir pour les exemples suivants.
 - Segmentation de String
 
 ```shell
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 
 - Transformation des tokens en majuscules
 
 ```shell
-iex> "Elixir rocks" |> String.upcase |> String.split
+iex> "Elixir rocks" |> String.upcase() |> String.split()
 ["ELIXIR", "ROCKS"]
 ```
 

--- a/ta/lessons/basics/pipe-operator.md
+++ b/ta/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: குழாய் செயல்பாடு
 ---
 
@@ -30,14 +30,14 @@ other_function() |> new_function() |> baz() |> bar() |> foo()
 - சரத்தினை சிறுகூறுகளாக உடைக்க
 
 ```elixir
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 
 - சரத்தின் கூறுகளனைத்தையும் பெரியஎழுத்துக்கு மாற்ற
 
 ```elixir
-iex> "Elixir rocks" |> String.upcase |> String.split
+iex> "Elixir rocks" |> String.upcase() |> String.split()
 ["ELIXIR", "ROCKS"]
 ```
 

--- a/th/lessons/basics/pipe-operator.md
+++ b/th/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Pipe Operator
 redirect_from:
   - /lessons/basics/pipe-operator/
@@ -35,14 +35,14 @@ other_function() |> new_function() |> baz() |> bar() |> foo()
 - Tokenize String (อย่างง่าย)
 
 ```elixir
-iex> "Elixir rocks" |> String.split
+iex> "Elixir rocks" |> String.split()
 ["Elixir", "rocks"]
 ```
 
 - ทำให้เป็นอักษรใหญ่ทุกๆ token
 
 ```elixir
-iex> "Elixir rocks" |> String.upcase |> String.split
+iex> "Elixir rocks" |> String.upcase() |> String.split()
 ["ELIXIR", "ROCKS"]
 ```
 


### PR DESCRIPTION
English version of pipe-operator lesson wasn't formatted as others.
This commit fixes next error: There is an error in the version definition of this chapter.
[1, 0, 0] vs "1.0.1"