### PR TITLE
Changes link to point correctly to en subfolder

### DIFF
--- a/_assets/javascripts/app.js
+++ b/_assets/javascripts/app.js
@@ -21,7 +21,7 @@ var toggle_section = function() {
 };
 
 var show_vcs_history = function() {
-  var base = 'https://github.com/elixirschool/elixirschool/commits/master/lessons/',
+  var base = 'https://github.com/elixirschool/elixirschool/commits/master/en/lessons/',
       path = window.location
     .toString()
     .split('/')


### PR DESCRIPTION
Is there a better way than hardcoding the default language?