### PR TITLE
Escripts: Better practice in mixfile

### DIFF
--- a/cn/lessons/advanced/escripts.md
+++ b/cn/lessons/advanced/escripts.md
@@ -25,10 +25,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/de/lessons/advanced/escripts.md
+++ b/de/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ Als nächstes müssen wir für unser Projekt in unserem Mixfile die `:escript` O
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/en/lessons/advanced/escripts.md
+++ b/en/lessons/advanced/escripts.md
@@ -28,10 +28,10 @@ Next we need to update our Mixfile to include the `:escript` option for our proj
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/es/lessons/advanced/escripts.md
+++ b/es/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ Después necesitaremos actualizar nuestro Mixfile para incluir la opción `:escr
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/gr/lessons/advanced/escripts.md
+++ b/gr/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/id/lessons/advanced/escripts.md
+++ b/id/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ Kemudian kita perlu mengubah Mixfile kita untuk memasukkan opsi `:escript` ke pr
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/jp/lessons/advanced/escripts.md
+++ b/jp/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/ko/lessons/advanced/escripts.md
+++ b/ko/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/pl/lessons/advanced/escripts.md
+++ b/pl/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ Następnie w pliku mixa dodajemy sekcję `:escript`, która zawiera opcję `:mai
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/pt/lessons/advanced/escripts.md
+++ b/pt/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ A seguir nós precisamos atualizar nosso Mixfile incluindo a opção `:escript` 
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/ru/lessons/advanced/escripts.md
+++ b/ru/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/sk/lessons/advanced/escripts.md
+++ b/sk/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ end
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end

--- a/vi/lessons/advanced/escripts.md
+++ b/vi/lessons/advanced/escripts.md
@@ -26,10 +26,10 @@ Tiếp theo chúng ta cần cập nhật Mixfile để chèn vào tùy chọn `:
 ```elixir
 defmodule ExampleApp.Mixfile do
   def project do
-    [app: :example_app, version: "0.0.1", escript: escript]
+    [app: :example_app, version: "0.0.1", escript: escript()]
   end
 
-  def escript do
+  defp escript do
     [main_module: ExampleApp.CLI]
   end
 end


### PR DESCRIPTION
Similar to how the deps are initialized in a fresh mix project, we should declare the escript argument using brackets (to signify that it is a function) and the function itself should be private (because it is never accessed outside of the module).

## Translations

- [x] cn
- [x] de
- [x] en
- [x] es
- [x] gr
- [x] id
- [x] jp
- [x] ko
- [x] pl
- [x] pt
- [x] ru
- [x] sk
- [x] vi

## Not applicable translations

The following translations do not contain the relevant section.

- ar
- bg
- bn
- fr
- it
- my
- no
- ta
- th
- tr
- tw
- uk