### PR TITLE
[KO] Molded some sentences to clear explanation for spawn linkage on concurrency chapter.

### DIFF
--- a/ko/lessons/advanced/concurrency.md
+++ b/ko/lessons/advanced/concurrency.md
@@ -67,7 +67,7 @@ iex> send pid, :ok
 
 ### 프로세스 연결
 
-`spawn`을 다룰 때, 프로세스가 언제 충돌하는지도 생각해봐야 합니다. 이런 경우에는 `spawn_link`로 프로세스를 연결할 필요가 있습니다. 두 연결된 프로세스는 다른 프로세스로부터 종료 신호를 수신하게 될 것입니다.
+`spawn`을 다룰 때 유념할 점은 프로세스가 비정상적으로 종료(crash)되었는지 여부를 판단하는 것입니다. 이를 위해서는 `spawn_link`를 통해 프로세스를 서로 연결할 수 있습니다. 이렇게 연결된 두 프로세스는 상대방 프로세스로부터 종료 신호를 수신할 수 있게 됩니다.
 
 ```elixir
 defmodule Example do
@@ -81,7 +81,7 @@ iex> spawn_link(Example, :explode, [])
 ** (EXIT from #PID<0.57.0>) evaluator process exited with reason: :kaboom
 ```
 
-연결된 프로세스가 다른 프로세스와 충돌하지 않도록 하고 싶을 때도 있습니다. 이런 경우에는, 종료 신호를 trap 해야할 필요가 있습니다. 종료 신호를 trap할 때, 다음과 같은 튜플 메시지를 수신하게 될 것입니다. `{:EXIT, from_pid, reason}`
+가끔은 연결된 프로세스로 인해 현재의 프로세스가 함께 종료되는 것을 막아야할 때도 있습니다. 이를 위해서는 종료 신호를 인지하여 이를 적절하게 처리해 주어야 하는데 이 때 사용되는 것이 `Process/flag2`입니다. 이 예시 모듈에서는 얼랭(erlang)의 [process_flag](http://erlang.org/doc/man/erlang.html#process_flag-2) 함수를 이용해서 `trap_exit` 플래그를 처리합니다. 종료 신호를 trap할 때, 다음과 같은 튜플 메시지를 수신하게 될 것입니다. `{:EXIT, from_pid, reason}`
 - [역주] trap 명령은 시스템에서 비동기적으로 발생하는 신호를 잡아서 필요한 작업을 수행하게 해주는 명령입니다.
 
 ```elixir


### PR DESCRIPTION
I've molded some sentences to clear explanation for `spawn linkage` on concurrency chapter and added a missing phrase for `process_flag`. #1284 