### PR TITLE
Update Gemfile for ruby higher version support 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '~>2.3.1'
 
 gem 'autoprefixer-rails'
 gem 'jekyll'


### PR DESCRIPTION
Support for higher Ruby versions when `bundle install` is executed to avoid `_Your Ruby version is 2.x.x, but your Gemfile specified 2.3.1_` Log. 
