### PR TITLE
[vi] Fix typo in control structures lesson

### DIFF
--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -49,7 +49,7 @@ iex> case {:ok, "Xin chào!"} do
 "Xin chào"
 ```
 
-Việc bao gồm biến `_` là một phần quan trong mệnh đề `case`. Không có nó Elixir sẽ văng lỗi nếu không tìm thấy mẫu trùng khớp:
+Việc bao gồm biến `_` là một phần quan trọng trong mệnh đề `case`. Không có nó Elixir sẽ văng lỗi nếu không tìm thấy mẫu trùng khớp:
 
 ```elixir
 iex> case :cam do
@@ -124,7 +124,7 @@ iex> cond do
 
 ## `with`
 
-`with` được dùng khi bạn muốn sử dụng một mệnh đề `case` lồng ghép hay những trường hợp không thể nó không thể kết nối lại một cách trơn tru được. Biểu thức `with` là sự kết hợp của từ khóa, generators và cuối cùng là một biểu thức.
+`with` được dùng khi bạn muốn sử dụng một mệnh đề `case` lồng ghép hay những trường hợp không thể kết nối lại một cách trơn tru được. Biểu thức `with` là sự kết hợp của từ khóa, generators và cuối cùng là một biểu thức.
 
 Chúng ta sẽ xem thêm về generators ở bài List Comprehensions nhưng bây giờ ta chỉ cần biết là chúng dùng pattern matching để so sánh biểu thức bên phải với biểu thức bên trái (cách nhau bởi dấu `<-`)
 


### PR DESCRIPTION
This is just a small typo, please review ヽ(＊>∇<)ﾉ