### PR TITLE
[PT] Correcting the definition of private macro and some and orthography issues

### DIFF
--- a/pt/lessons/advanced/metaprogramming.md
+++ b/pt/lessons/advanced/metaprogramming.md
@@ -130,7 +130,7 @@ end
 
 ### Macros Privados
 
-Embora não seja tão comum, Elixir suporta macros privadas. Um macro privado é definido com `defmacro` e só pode ser chamado a partir do módulo no qual ele foi definido. Macros privados devem ser definidas antes do código que as invoca.
+Embora não seja tão comum, Elixir suporta macros privadas. Um macro privado é definido com `defmacrop` e só pode ser chamado a partir do módulo no qual ele foi definido. Macros privados devem ser definidas antes do código que as invoca.
 
 ### Higienização de Macros
 

--- a/pt/lessons/libraries/bypass.md
+++ b/pt/lessons/libraries/bypass.md
@@ -7,7 +7,7 @@ redirect_from:
 
 Ao testar nossas aplicações, muitas vezes precisamos fazer chamadas a serviços externos.
 Podemos até mesmo querer simular diferentes situações como erros inesperados do servidor.
-Tratar issso de modo eficiente não é fácil no Elixir sem uma pequena ajuda.
+Tratar isso de modo eficiente não é fácil no Elixir sem uma pequena ajuda.
 
 Nesta lição vamos explorar como [bypass](https://github.com/PSPDFKit-labs/bypass) pode nos ajudar rapidamente e tratar facilmente essas chamadas em nossos testes.
 


### PR DESCRIPTION
Change `defmacro` to `defmacrop` on [Metaprogramming section > Private Macros](https://elixirschool.com/pt/lessons/advanced/metaprogramming/#macros-privados)