### PR TITLE
Fix link for japanese

### DIFF
--- a/bg/index.md
+++ b/bg/index.md
@@ -6,12 +6,12 @@ title: Elixir School
 
 Уроци за езика за програмиране Elixir, вдъхновени от [Scala School](http://twitter.github.io/scala_school/) на Twitter.
 
-Преведен и на [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [L'italiano][it] и други.
+Преведен и на [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [L'italiano][it] и други.
 
   [cn]: /cn/
   [es]: /es/
   [it]: /it/
-  [jp]: /jp/
+  [ja]: /ja/
   [ko]: /ko/
   [pl]: /pl/
   [pt]: /pt/

--- a/bn/index.md
+++ b/bn/index.md
@@ -5,12 +5,12 @@ title: Elixir School
 [![লাইসেন্স](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 এলিক্সির প্রোগ্রামিং ভাষা এর অধ্যায় সমুহ, Twitter এর [Scala School](http://twitter.github.io/scala_school/) দ্বারা অনুপ্রাণিত।
-আরও পাওয়া যাবে [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [L'italiano][it], [Deutsch][de], [বাংলা](#) ভাষাতে।
+আরও পাওয়া যাবে [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [L'italiano][it], [Deutsch][de], [বাংলা](#) ভাষাতে।
 
   [cn]: /cn/
   [es]: /es/
   [it]: /it/
-  [jp]: /jp/
+  [ja]: /ja/
   [ko]: /ko/
   [pl]: /pl/
   [pt]: /pt/

--- a/en/index.md
+++ b/en/index.md
@@ -7,12 +7,12 @@ redirect_from: /
 
 Lessons about the Elixir programming language, inspired by Twitter's [Scala School](http://twitter.github.io/scala_school/).
 
-Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], [ภาษาไทย][th] and others.
+Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], [ภาษาไทย][th] and others.
 
   [cn]: /cn/
   [es]: /es/
   [it]: /it/
-  [jp]: /jp/
+  [ja]: /ja/
   [ko]: /ko/
   [pl]: /pl/
   [pt]: /pt/


### PR DESCRIPTION
There is some missed codes not replaced from `jp`

Please review this @marocchino @doomspork 