### PR TITLE
Add a section on race conditions with ETS tables

### DIFF
--- a/en/lessons/specifics/ets.md
+++ b/en/lessons/specifics/ets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: Erlang Term Storage (ETS)
 redirect_from:
   - /lessons/specifics/ets/

--- a/en/lessons/specifics/ets.md
+++ b/en/lessons/specifics/ets.md
@@ -50,6 +50,12 @@ Access control in ETS is similar to access control within modules:
 + `protected` — Read available to all processes.  Only writable by owner process.  This is the default.
 + `private` — Read/Write limited to owner process.
 
+## Race Conditions
+
+If more than one process can write to a table - whether via `:public` access or by messages to the owning process - race conditions are possible.  For example, two processes each read a counter value of `0`, increment it, and write `1`; the end result reflects only a single increment.
+
+For counters specifically, [:ets.update_counter/3](http://erlang.org/doc/man/ets.html#update_counter-3) provides for atomic update-and-read.  For other cases, it may be necessary for the owner process to perform custom atomic operations in response to messages, such as "add this value to the list at key `:results`".
+
 ## Inserting data
 
 ETS has no schema.  The only limitation is that data must be stored as a tuple whose first element is the key.  To add new data we can use `insert/2`:


### PR DESCRIPTION
I'm not sure if this is the best place in the document to add this, but as soon as I read that `:public` access was possible, I wanted to know how race conditions could be prevented. After reading and experimenting, this is what I came up with.