### PR TITLE
static analysis of code -> statically analyze code

### DIFF
--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -123,7 +123,7 @@ iex>
 
 Notice how you can use markup within our documentation and the terminal will render it? Apart from really being cool and a novel addition to Elixir's vast ecosystem, it gets much more interesting when we look at ExDoc to generate HTML documentation on the fly.
 
-**Note:** the `@spec` annotation is used to static analysis of code. To learn more about it, check out the [Specifications and types](../../advanced/typespec) lesson.
+**Note:** the `@spec` annotation is used to statically analyze code. To learn more about it, check out the [Specifications and types](../../advanced/typespec) lesson.
 
 ## ExDoc
 


### PR DESCRIPTION
Slight typo here that could alternatively read "used to do static analysis of code." Let me know if you'd prefer that.