### PR TITLE
mix-tasks.md: fix typos and inconsistencies

### DIFF
--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -61,7 +61,7 @@ Now, in our **lib/hello.ex** file that Mix generated for us, let's create a simp
 ```elixir
 defmodule Hello do
   @doc """
-  Output's `Hello, World!` everytime.
+  Outputs `Hello, World!` every time.
   """
   def say do
     IO.puts("Hello, World!")
@@ -77,7 +77,7 @@ Let's create our custom Mix task. Create a new directory and file **hello/lib/mi
 defmodule Mix.Tasks.Hello do
   use Mix.Task
 
-  @shortdoc "Simply runs the Hello.say/0 command."
+  @shortdoc "Simply runs the Hello.say/0 function"
   def run(_) do
     # calling our Hello.say() function from earlier
     Hello.say()
@@ -110,6 +110,6 @@ $ mix help
 
 mix app.start         # Starts all registered apps
 ...
-mix hello             # Simply calls the Hello.say/0 function.
+mix hello             # Simply calls the Hello.say/0 function
 ...
 ```


### PR DESCRIPTION
I also removed the `.` from the end of the shortdoc, which was my own editorial preference. None of the other task descriptions  given by `mix help` have a `.` at the end, why should this one?