### PR TITLE
iex-helpers: Remove `s` section

### DIFF
--- a/bn/lessons/basics/iex-helpers.md
+++ b/bn/lessons/basics/iex-helpers.md
@@ -199,23 +199,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-`s` দিয়ে আমরা কোন মডিউল অথবা ফাংশনের টাইপ স্পেক সংক্রান্ত তথ্য জানতে পারি। জানতে পারি তারা কি ধরণের ইনপুট আশা করে। 
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 `t` হেল্পারের মাধ্যমে আমরা একটি মডিউলের টাইপ সম্পর্কে জানতে পারি। 

--- a/de/lessons/basics/iex-helpers.md
+++ b/de/lessons/basics/iex-helpers.md
@@ -211,23 +211,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Mit `s` können wir die Typenspezifikation für ein Modul oder eine Funktion abrufen. Das ist z.B. hilfreich um herauszufinden, welche Parameter eine Funktion erwartet:
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 Die `t` Hilfsfunktion gibt Auskunft über die in einem Modul verfügbaren Typen:

--- a/en/lessons/basics/iex-helpers.md
+++ b/en/lessons/basics/iex-helpers.md
@@ -210,23 +210,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-With `s` we can retrieve the type spec information for a module or function. We can use this to know what it expects:
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 The `t` helper tells us about Types available in a given module:

--- a/gr/lessons/basics/iex-helpers.md
+++ b/gr/lessons/basics/iex-helpers.md
@@ -208,23 +208,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Με τον `s` μπορούμε να ανακτήσουμε τις πληροφορίες προδιαγραφής τύπων για μια ενότητα ή μια συνάρτηση, μπορούμε να τον χρησιμποιήσουμε για να ξέρουμε ότι αναμένει:
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 Ο βοηθός `t` μας λέει για τους διαθέσιμους τύπους σε μια δοθείσα ενότητα.

--- a/ja/lessons/basics/iex-helpers.md
+++ b/ja/lessons/basics/iex-helpers.md
@@ -212,23 +212,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-`s`ヘルパーはモジュールや関数の型仕様を取得することができます。このヘルパーによって、その関数が何を期待するか知ることができます。
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 `t`ヘルパーは引数に渡したモジュールの利用可能な型を見ることができます。

--- a/ko/lessons/basics/iex-helpers.md
+++ b/ko/lessons/basics/iex-helpers.md
@@ -208,23 +208,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-`s`를 사용하여 모듈이나 함수의 명세를 확인하고, 이것들이 무엇을 기대하는지 확인할 수 있습니다.
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# 이는 모듈에도 동작합니다.
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 `t` 헬퍼는 주어진 모듈에서 사용 가능한 타입을 알려줍니다.

--- a/no/lessons/basics/iex-helpers.md
+++ b/no/lessons/basics/iex-helpers.md
@@ -204,23 +204,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Med `s` så kan vi få tak i type spesifikasjon informasjonen for en modul eller funksjon, vi kan bruke dette for å vite hva den forventer.
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 hjelperen `t` forteller oss om typer tilgjenglig i en gitt modul:

--- a/pl/lessons/basics/iex-helpers.md
+++ b/pl/lessons/basics/iex-helpers.md
@@ -206,23 +206,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Za pomocą `s` możemy poznać specyfikację modułu lub funkcji. Sposób użycia nie odbiega od innych:
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 `t` mówi nam jakie typy mamy dostępne w danym module:

--- a/pt/lessons/basics/iex-helpers.md
+++ b/pt/lessons/basics/iex-helpers.md
@@ -206,23 +206,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Com `s` podemos recuperar informação do tipo de especificação de um módulo ou função, podemos usá-lo para saber o que se espera.
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# Também funciona nos módulos
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 O `t` helper nos diz sobre Tipos disponíveis em um dado módulo:

--- a/sk/lessons/basics/iex-helpers.md
+++ b/sk/lessons/basics/iex-helpers.md
@@ -210,23 +210,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-Pomocou `s` môžeme získať informácie o špecifikácii modulu alebo funkcie. Môžeme to použiť ako vodítko, kde vieme čo od nás očakáva:
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
 Pomocná funkcia `t` nám povie aké typy sú dostupne v danom module:

--- a/tw/lessons/basics/iex-helpers.md
+++ b/tw/lessons/basics/iex-helpers.md
@@ -206,23 +206,6 @@ warning: redefining module MyProject (current version loaded from _build/dev/lib
 {:reloaded, MyProject, [MyProject]}
 ```
 
-### `s`
-
-使用 `s` 可以檢索模組或函數的型別規格資訊 (type spec information)。可以用它來了解模組或函數的可能功用：
-
-```elixir
-iex> s Map.merge/2
-@spec merge(map(), map()) :: map()
-
-# it also works on entire modules
-iex> s Map
-@spec get(map(), key(), value()) :: value()
-@spec put(map(), key(), value()) :: map()
-# ...
-@spec get(map(), key()) :: value()
-@spec get_and_update!(map(), key(), (value() -> {get, value()})) :: {get, map()} | no_return() when get: term()
-```
-
 ### `t`
 
  `t` helper 告訴我們關於所給定模組中的可用型別：


### PR DESCRIPTION
Fixes #1358

As noted in #1358, the `s` helper has been removed from Elixir 1.6.0, as
the same information is available in output from the `h` helper.