### PR TITLE
Add extra note to "function clause pinning" section

### DIFF
--- a/en/lessons/basics/pattern-matching.md
+++ b/en/lessons/basics/pattern-matching.md
@@ -97,4 +97,8 @@ iex> greet.("Hello", "Sean")
 "Hi Sean"
 iex> greet.("Mornin'", "Sean")
 "Mornin', Sean"
+iex> greeting
+"Hello"
 ```
+
+Note in the `"Mornin'"` example that the reassignment of `greeting` to `"Mornin'"` only happens inside the function. Outside of the function `greeting` is still `"Hello"`.


### PR DESCRIPTION
To show that the reassignment of the `greeting` variable is local to the
function and doesn't affect the outer scope.