### PR TITLE
fixes out-dated URL for "Expressions allowed in guard clauses"

### DIFF
--- a/bg/lessons/basics/control-structures.md
+++ b/bg/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Проветеве официалната документация за [Допустими изрази в предпазващи клаузи](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Проветеве официалната документация за [Допустими изрази в предпазващи клаузи](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/bg/lessons/basics/control-structures.md
+++ b/bg/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Проветеве официалната документация за [Допустими изрази в предпазващи клаузи](https://hexdocs.pm/elixir/master/guards.html).
+Проветеве официалната документация за [Допустими изрази в предпазващи клаузи](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/bn/lessons/basics/control-structures.md
+++ b/bn/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-আরও জানতে হলে অফিসিয়াল ডকুমেন্টেশানের [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) চ্যাপ্টারটি দেখুন।
+আরও জানতে হলে অফিসিয়াল ডকুমেন্টেশানের [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions) চ্যাপ্টারটি দেখুন।
 
 ## `cond`
 

--- a/bn/lessons/basics/control-structures.md
+++ b/bn/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-আরও জানতে হলে অফিসিয়াল ডকুমেন্টেশানের [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses) চ্যাপ্টারটি দেখুন। 
+আরও জানতে হলে অফিসিয়াল ডকুমেন্টেশানের [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) চ্যাপ্টারটি দেখুন।
 
 ## `cond`
 

--- a/cn/lessons/basics/control-structures.md
+++ b/cn/lessons/basics/control-structures.md
@@ -90,7 +90,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-参考官方的文档来看[卫兵支持的表达式](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses)
+参考官方的文档来看[卫兵支持的表达式](https://hexdocs.pm/elixir/master/guards.html)
 
 ## `cond`
 当我们需要匹配条件而不是值的时候，可以使用 `cond`，这和其他语言的 `else if` 或者 `elsif` 相似：

--- a/cn/lessons/basics/control-structures.md
+++ b/cn/lessons/basics/control-structures.md
@@ -90,7 +90,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-参考官方的文档来看[卫兵支持的表达式](https://hexdocs.pm/elixir/master/guards.html)
+参考官方的文档来看[卫兵支持的表达式](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions)
 
 ## `cond`
 当我们需要匹配条件而不是值的时候，可以使用 `cond`，这和其他语言的 `else if` 或者 `elsif` 相似：

--- a/de/lessons/basics/control-structures.md
+++ b/de/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Schau in die offizielle Dokumentation für [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses), um mehr über guard clauses zu erfahren.
+Schau in die offizielle Dokumentation für [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html), um mehr über guard clauses zu erfahren.
 
 ## `cond`
 

--- a/de/lessons/basics/control-structures.md
+++ b/de/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Schau in die offizielle Dokumentation für [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html), um mehr über guard clauses zu erfahren.
+Schau in die offizielle Dokumentation für [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions), um mehr über guard clauses zu erfahren.
 
 ## `cond`
 

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Check the official docs for [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Check the official docs for [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Check the official docs for [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+Check the official docs for [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/es/lessons/basics/control-structures.md
+++ b/es/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Revisa la documentación oficial para [Expresiones permitidas en cláusulas de guardia](https://hexdocs.pm/elixir/master/guards.html).
+Revisa la documentación oficial para [Expresiones permitidas en cláusulas de guardia](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/es/lessons/basics/control-structures.md
+++ b/es/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Revisa la documentación oficial para [Expresiones permitidas en cláusulas de guardia](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Revisa la documentación oficial para [Expresiones permitidas en cláusulas de guardia](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/fr/lessons/basics/control-structures.md
+++ b/fr/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-La documentation pour [les expressions permises dans les guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+La documentation pour [les expressions permises dans les guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/fr/lessons/basics/control-structures.md
+++ b/fr/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-La documentation pour [les expressions permises dans les guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+La documentation pour [les expressions permises dans les guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/gr/lessons/basics/control-structures.md
+++ b/gr/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Θα ταιριάξει"
 ```
 
-Ελέγξτε τα επίσημα έγγραφα για τις [Εκφράσεις που επιτρέπονται στις ρήτρες προστασίας](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Ελέγξτε τα επίσημα έγγραφα για τις [Εκφράσεις που επιτρέπονται στις ρήτρες προστασίας](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/gr/lessons/basics/control-structures.md
+++ b/gr/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Θα ταιριάξει"
 ```
 
-Ελέγξτε τα επίσημα έγγραφα για τις [Εκφράσεις που επιτρέπονται στις ρήτρες προστασίας](https://hexdocs.pm/elixir/master/guards.html).
+Ελέγξτε τα επίσημα έγγραφα για τις [Εκφράσεις που επιτρέπονται στις ρήτρες προστασίας](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/id/lessons/basics/control-structures.md
+++ b/id/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Ceklah dokumentasi resmi untuk [Expression yang diijinkan dalam klausa penjaga](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Ceklah dokumentasi resmi untuk [Expression yang diijinkan dalam klausa penjaga](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/id/lessons/basics/control-structures.md
+++ b/id/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Ceklah dokumentasi resmi untuk [Expression yang diijinkan dalam klausa penjaga](https://hexdocs.pm/elixir/master/guards.html).
+Ceklah dokumentasi resmi untuk [Expression yang diijinkan dalam klausa penjaga](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/it/lessons/basics/control-structures.md
+++ b/it/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Leggi la documentazione ufficiale per [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Leggi la documentazione ufficiale per [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/it/lessons/basics/control-structures.md
+++ b/it/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Leggi la documentazione ufficiale per [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+Leggi la documentazione ufficiale per [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/ja/lessons/basics/control-structures.md
+++ b/ja/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-公式ドキュメントから[Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses)を読んでみてください。
+公式ドキュメントから[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html)を読んでみてください。
 
 ## `cond`
 

--- a/ja/lessons/basics/control-structures.md
+++ b/ja/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-公式ドキュメントから[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html)を読んでみてください。
+公式ドキュメントから[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions)を読んでみてください。
 
 ## `cond`
 

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 ...> end
 "Will match"
 ```
-[Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses) 공식 문서를 참고하십시오.
+[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) 공식 문서를 참고하십시오.
 
 ## `cond`
 

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 ...> end
 "Will match"
 ```
-[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) 공식 문서를 참고하십시오.
+[Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions) 공식 문서를 참고하십시오.
 
 ## `cond`
 

--- a/ms/lessons/basics/control-structures.md
+++ b/ms/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Lihat dokumen rasmi untuk [Kenyataan yang dibenarkan di dalam klausa 'guard'](https://hexdocs.pm/elixir/master/guards.html).
+Lihat dokumen rasmi untuk [Kenyataan yang dibenarkan di dalam klausa 'guard'](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/ms/lessons/basics/control-structures.md
+++ b/ms/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Lihat dokumen rasmi untuk [Kenyataan yang dibenarkan di dalam klausa 'guard'](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Lihat dokumen rasmi untuk [Kenyataan yang dibenarkan di dalam klausa 'guard'](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/no/lessons/basics/control-structures.md
+++ b/no/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Se den offisielle dokumentasjonen for [Tillatte uttrykk i beskyttelsesklausuler](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Se den offisielle dokumentasjonen for [Tillatte uttrykk i beskyttelsesklausuler](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/no/lessons/basics/control-structures.md
+++ b/no/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Se den offisielle dokumentasjonen for [Tillatte uttrykk i beskyttelsesklausuler](https://hexdocs.pm/elixir/master/guards.html).
+Se den offisielle dokumentasjonen for [Tillatte uttrykk i beskyttelsesklausuler](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/pl/lessons/basics/control-structures.md
+++ b/pl/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Więcej szczegółów znajdziesz w dokumentacji, w języku angielskim, [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+Więcej szczegółów znajdziesz w dokumentacji, w języku angielskim, [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/pl/lessons/basics/control-structures.md
+++ b/pl/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Więcej szczegółów znajdziesz w dokumentacji, w języku angielskim, [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Więcej szczegółów znajdziesz w dokumentacji, w języku angielskim, [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/pt/lessons/basics/control-structures.md
+++ b/pt/lessons/basics/control-structures.md
@@ -86,7 +86,7 @@ iex> case {1, 2, 3} do
 ...> end
 "Will match"
 ```
-Verifique a documentação oficial sobre [Expressões permitidas em clausulas guard](https://hexdocs.pm/elixir/master/guards.html).
+Verifique a documentação oficial sobre [Expressões permitidas em clausulas guard](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/pt/lessons/basics/control-structures.md
+++ b/pt/lessons/basics/control-structures.md
@@ -86,7 +86,7 @@ iex> case {1, 2, 3} do
 ...> end
 "Will match"
 ```
-Verifique a documentação oficial sobre [Expressões permitidas em clausulas guard](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Verifique a documentação oficial sobre [Expressões permitidas em clausulas guard](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/ru/lessons/basics/control-structures.md
+++ b/ru/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Также советуем почитать официальную документацию про [выражения, доступные в ограничивающих выражениях](https://hexdocs.pm/elixir/master/guards.html).
+Также советуем почитать официальную документацию про [выражения, доступные в ограничивающих выражениях](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/ru/lessons/basics/control-structures.md
+++ b/ru/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Также советуем почитать официальную документацию про [выражения, доступные в ограничивающих выражениях](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Также советуем почитать официальную документацию про [выражения, доступные в ограничивающих выражениях](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/sk/lessons/basics/control-structures.md
+++ b/sk/lessons/basics/control-structures.md
@@ -90,7 +90,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Pozrite si príslušnú kapitolu v oficiálnej dokumentácii [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+Pozrite si príslušnú kapitolu v oficiálnej dokumentácii [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`

--- a/sk/lessons/basics/control-structures.md
+++ b/sk/lessons/basics/control-structures.md
@@ -90,7 +90,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Pozrite si príslušnú kapitolu v oficiálnej dokumentácii [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Pozrite si príslušnú kapitolu v oficiálnej dokumentácii [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/ta/lessons/basics/control-structures.md
+++ b/ta/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-[காப்புகளில் பயன்படுத்தக்கூடிய கோவைகள்](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses) குறித்து மேலும் அறிந்துகொள்ள அதன் அதிகாரபூர்வ ஆவணங்களைப்பார்க்கவும்.
+[காப்புகளில் பயன்படுத்தக்கூடிய கோவைகள்](https://hexdocs.pm/elixir/master/guards.html) குறித்து மேலும் அறிந்துகொள்ள அதன் அதிகாரபூர்வ ஆவணங்களைப்பார்க்கவும்.
 
 ## `cond`
 

--- a/ta/lessons/basics/control-structures.md
+++ b/ta/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-[காப்புகளில் பயன்படுத்தக்கூடிய கோவைகள்](https://hexdocs.pm/elixir/master/guards.html) குறித்து மேலும் அறிந்துகொள்ள அதன் அதிகாரபூர்வ ஆவணங்களைப்பார்க்கவும்.
+[காப்புகளில் பயன்படுத்தக்கூடிய கோவைகள்](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions) குறித்து மேலும் அறிந்துகொள்ள அதன் அதிகாரபூர்வ ஆவணங்களைப்பார்க்கவும்.
 
 ## `cond`
 

--- a/th/lessons/basics/control-structures.md
+++ b/th/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-ดู official doc เพิ่มเติมเกี่ยวกับ [Expression ที่ใช้ได้กับ guard clauses](https://hexdocs.pm/elixir/master/guards.html).
+ดู official doc เพิ่มเติมเกี่ยวกับ [Expression ที่ใช้ได้กับ guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/th/lessons/basics/control-structures.md
+++ b/th/lessons/basics/control-structures.md
@@ -92,7 +92,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-ดู official doc เพิ่มเติมเกี่ยวกับ [Expression ที่ใช้ได้กับ guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+ดู official doc เพิ่มเติมเกี่ยวกับ [Expression ที่ใช้ได้กับ guard clauses](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/tr/lessons/basics/control-structures.md
+++ b/tr/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "x sifirdan buyuk"
 ```
 
-Elixir resmi dokumanlarindan devamini inceleyebilirsiniz. [Kosullu karsilastimalar (guard clauses) hakkinda daha fazla](https://hexdocs.pm/elixir/master/guards.html).
+Elixir resmi dokumanlarindan devamini inceleyebilirsiniz. [Kosullu karsilastimalar (guard clauses) hakkinda daha fazla](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/tr/lessons/basics/control-structures.md
+++ b/tr/lessons/basics/control-structures.md
@@ -94,7 +94,7 @@ iex> case {1, 2, 3} do
 "x sifirdan buyuk"
 ```
 
-Elixir resmi dokumanlarindan devamini inceleyebilirsiniz. [Kosullu karsilastimalar (guard clauses) hakkinda daha fazla](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Elixir resmi dokumanlarindan devamini inceleyebilirsiniz. [Kosullu karsilastimalar (guard clauses) hakkinda daha fazla](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/tw/lessons/basics/control-structures.md
+++ b/tw/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-查看官方文件來獲得 [Expressions allowed in guard clauses](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses) 資訊。
+查看官方文件來獲得 [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) 資訊。
 
 ## `cond`
 

--- a/tw/lessons/basics/control-structures.md
+++ b/tw/lessons/basics/control-structures.md
@@ -93,7 +93,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-查看官方文件來獲得 [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/master/guards.html) 資訊。
+查看官方文件來獲得 [Expressions allowed in guard clauses](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions) 資訊。
 
 ## `cond`
 

--- a/uk/lessons/basics/control-structures.md
+++ b/uk/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Також рекомендуємо почитати офіційну документацію про [вирази, доступні в обмежувальних виразах](https://hexdocs.pm/elixir/master/guards.html).
+Також рекомендуємо почитати офіційну документацію про [вирази, доступні в обмежувальних виразах](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 ## `cond`
 

--- a/uk/lessons/basics/control-structures.md
+++ b/uk/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Will match"
 ```
 
-Також рекомендуємо почитати офіційну документацію про [вирази, доступні в обмежувальних виразах](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Також рекомендуємо почитати офіційну документацію про [вирази, доступні в обмежувальних виразах](https://hexdocs.pm/elixir/master/guards.html).
 
 ## `cond`
 

--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Trùng"
 ```
 
-Xem tài liệu tại trang chủ về [Biểu thức hợp lệ trong mệnh đề guard](http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses).
+Xem tài liệu tại trang chủ về [Biểu thức hợp lệ trong mệnh đề guard](https://hexdocs.pm/elixir/master/guards.html).
 
 
 ## `cond`

--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -91,7 +91,7 @@ iex> case {1, 2, 3} do
 "Trùng"
 ```
 
-Xem tài liệu tại trang chủ về [Biểu thức hợp lệ trong mệnh đề guard](https://hexdocs.pm/elixir/master/guards.html).
+Xem tài liệu tại trang chủ về [Biểu thức hợp lệ trong mệnh đề guard](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions).
 
 
 ## `cond`


### PR DESCRIPTION
Noticed that this URL was out of date and found the URL.