### PR TITLE
Allow plug ex. to set plug_status on exception

### DIFF
--- a/cn/lessons/specifics/plug.md
+++ b/cn/lessons/specifics/plug.md
@@ -118,6 +118,7 @@ end
 ```elixir
 defmodule Example.Plug.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -238,6 +238,7 @@ Edit `lib/example/router.ex` and make the following changes:
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/es/lessons/specifics/plug.md
+++ b/es/lessons/specifics/plug.md
@@ -235,6 +235,7 @@ Edita `lib/example/router.ex` y realiza los siguientes cambios:
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/gr/lessons/specifics/plug.md
+++ b/gr/lessons/specifics/plug.md
@@ -236,6 +236,7 @@ end
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/id/lessons/specifics/plug.md
+++ b/id/lessons/specifics/plug.md
@@ -118,6 +118,7 @@ Mari tambahkan Plug kita ke router tersebut:
 ```elixir
 defmodule Example.Plug.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/ja/lessons/specifics/plug.md
+++ b/ja/lessons/specifics/plug.md
@@ -210,6 +210,7 @@ end
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/ko/lessons/specifics/plug.md
+++ b/ko/lessons/specifics/plug.md
@@ -237,6 +237,7 @@ end
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/pl/lessons/specifics/plug.md
+++ b/pl/lessons/specifics/plug.md
@@ -118,6 +118,7 @@ Dodajmy nasz plug do routera:
 ```elixir
 defmodule Example.Plug.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/pt/lessons/specifics/plug.md
+++ b/pt/lessons/specifics/plug.md
@@ -221,6 +221,7 @@ Edite o `lib/example/router.ex` e adicione as seguintes mudanças:
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/ru/lessons/specifics/plug.md
+++ b/ru/lessons/specifics/plug.md
@@ -218,6 +218,7 @@ end
 ```elixir
 defmodule Example.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 

--- a/vi/lessons/specifics/plug.md
+++ b/vi/lessons/specifics/plug.md
@@ -118,6 +118,7 @@ Và ta thêm Plug của chúng ta vào router:
 ```elixir
 defmodule Example.Plug.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Example.Plug.VerifyRequest
 


### PR DESCRIPTION
Without `use Plug.ErrorHandler` every raised exception would default to
a status code of 500. This resolves that. The example could probably
also include the overwriting of the `handle_errors/2` callback but it
may not be necessary especially considering that it looks like Plug is
(thankfully) trying to get people to not use exceptions for regular
control flow. The example will fallback to body text of "Something went
wrong", however.