### PR TITLE
[EN] Semicolon replaced with a dot

### DIFF
--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -11,7 +11,7 @@ In this lesson we will look at the control structures available to us in Elixir.
 
 ## `if` and `unless`
 
-Chances are you've encountered `if/2` before, and if you've used Ruby you're familiar with `unless/2`.  In Elixir they work much the same way but they are defined as macros, not language constructs; You can find their implementation in the [Kernel module](https://hexdocs.pm/elixir/Kernel.html).
+Chances are you've encountered `if/2` before, and if you've used Ruby you're familiar with `unless/2`.  In Elixir they work much the same way but they are defined as macros, not language constructs. You can find their implementation in the [Kernel module](https://hexdocs.pm/elixir/Kernel.html).
 
 It should be noted that in Elixir, the only falsey values are `nil` and the boolean `false`.
 


### PR DESCRIPTION
Hi All,

I think I noticed something that might be considered as a small mistake. Since the phrase ` You can find their implementation` starts with upper Y it might be a good idea to replace semicolon with a dot.

Hope this helps.

Cheers,
Rafal