### PR TITLE
Update supervisor examples to Elixir 1.6

### DIFF
--- a/en/lessons/advanced/otp-supervisors.md
+++ b/en/lessons/advanced/otp-supervisors.md
@@ -13,25 +13,56 @@ Supervisors are specialized processes with one purpose: monitoring other process
 
 The magic of Supervisors is in the `Supervisor.start_link/2` function.  In addition to starting our supervisor and children, it allows us to define the strategy our supervisor uses for managing child processes.
 
-Children are defined using a list and the `worker/3` function we imported from `Supervisor.Spec`.  The `worker/3` function takes a module, arguments, and a set of options.  Under the hood `worker/3` calls `start_link/3` with our arguments during initialization.
+Using the `SimpleQueue` from the [OTP Concurrency](../../advanced/otp-concurrency) lesson, let's get started:
 
-Using the SimpleQueue from the [OTP Concurrency](../../advanced/otp-concurrency) lesson let's get started:
+Create a new project using `mix new simple_queue --sup` to create a new project with a supervisor tree.  The code for the `SimpleQueue` module should go in `lib/simple_queue.ex` and the supervisor code we'll be adding will go in `lib/simple_queue/application.ex`
+
+Children are defined using a list, either a list module names:
 
 ```elixir
-import Supervisor.Spec
+defmodule SimpleQueue.Application do
+  use Application
 
-children = [
-  worker(SimpleQueue, [], name: SimpleQueue)
-]
+  def start(_type, _args) do
+    children = [
+      SimpleQueue
+    ]
 
-{:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+    opts = [strategy: :one_for_one, name: SimpleQueue.Supervisor]
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end
 ```
 
-If our process were to crash or be terminated our Supervisor would automatically restart it as if nothing had happened.
+or a list of tuples if you want to include configuration options:
+
+```elixir
+defmodule SimpleQueue.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {SimpleQueue, [1, 2, 3]}
+    ]
+
+    opts = [strategy: :one_for_one, name: SimpleQueue.Supervisor]
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end
+```
+
+If we run `iex -S mix` we'll see that our `SimpleQueue` is automatically started:
+
+```elixir
+iex> SimpleQueue.queue
+[1, 2, 3]
+```
+
+If our `SimpleQueue` process were to crash or be terminated our Supervisor would automatically restart it as if nothing had happened.
 
 ### Strategies
 
-There are currently four different restart strategies available to supervisors:
+There are currently three different supervision strategies available to supervisors:
 
 + `:one_for_one` - Only restart the failed child process.
 
@@ -39,48 +70,76 @@ There are currently four different restart strategies available to supervisors:
 
 + `:rest_for_one` - Restart the failed process and any process started after it.
 
-+ `:simple_one_for_one` - Best for dynamically attached children. Supervisor spec is required to contain only one child, but this child can be spawned multiple times. This strategy is intended to be used when you need to dynamically start and stop supervised children.
+## Child Specification
 
-### Restart values
-
-There are several approaches for handling child process crashes:
-
-+ `:permanent` - Child is always restarted.
-
-+ `:temporary` - Child process is never restarted.
-
-+ `:transient` - Child process is restarted only if it terminates abnormally.
-
-It's not a required option, by default it's `:permanent`.
-
-### Nesting
-
-In addition to worker processes, we can also supervise supervisors to create a supervisor tree.  The only difference to us is swapping `supervisor/3` for `worker/3`:
+After the supervisor has started it must know how to start/stop/restart its children.  Each child module should have a `child_spec/1` function to define these behaviors.  The `use GenServer`, `use Supervisor`, and `use Agent` macros automatically define this method for us (`SimpleQueue` has `use Genserver`, so we do not need to modify the module), but if you need to define it yourself `child_spec/1` should return a map of options:
 
 ```elixir
-import Supervisor.Spec
+def child_spec(opts) do
+  %{
+    id: SimpleQueue,
+    start: {__MODULE__, :start_link, [opts]}
+    shutdown: 5_000
+    restart: :permanent
+    type: :worker
+  }
+end
+```
 
-children = [
-  supervisor(ExampleApp.ConnectionSupervisor, [[name: ExampleApp.ConnectionSupervisor]]),
-  worker(SimpleQueue, [[], [name: SimpleQueue]])
++ `id` - Required key.  Used by the supervisor to identify the child specification.
+
++ `start` - Required key.  The Module/Function/Arguments to call when started by the supervisor
+
++ `shutdown` - Optional key.  Defines child's behavior during shutdown.  Options are:
+
+  + `:brutal_kill` - Child is stopped immediately
+
+  + any positive integer - time in milliseconds supervisor will wait before killing child process.  If the process is a `:worker` type, this defaults to 5000.
+
+  + `:infinity` - Supervisor will wait indefinitely before killing child process.  Default for `:supervisor` process type.  Not recommended for `:worker` type.
+
++ `restart` - Optional key.  There are several approaches for handling child process crashes:
+
+  + `:permanent` - Child is always restarted. Default for all processes
+
+  + `:temporary` - Child process is never restarted.
+
+  + `:transient` - Child process is restarted only if it terminates abnormally.
+
++ `type` - Optional key. Processes can be either `:worker` or `:supervisor`. Defaults to `:worker`.
+
+## DynamicSupervisor
+
+Supervisors normally start with a list of children to start when the app starts.  However, sometimes the supervised children will not be known when our app starts up (for example, we may have a web app that starts a new process to handle a user connecting to our site). For these cases we will want a supervisor where the children can be started on demand.  The DynamicSupervisor is used to handle this case.
+
+Since we will not specify children, we only need to define the runtime options for the supervisor.  The DynamicSupervisor only supports the `:one_for_one` supervision strategy:
+
+```elixir
+options = [
+  name: SimpleQueue.Supervisor,
+  strategy: :one_for_one
 ]
 
-{:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+DynamicSupervisor.start_link(options)
+```
+
+Then, to start a new SimpleQueue dynamically we'll use `start_child/2` which takes a supervisor and the child specification (again, `SimpleQueue` uses `use GenServer` so the child specification is already defined):
+
+```elixir
+{:ok, pid} = DynamicSupervisor.start_child(SimpleQueue.Supervisor, SimpleQueue)
 ```
 
 ## Task Supervisor
 
-Tasks have their own specialized Supervisor, the `Task.Supervisor`.  Designed for dynamically created tasks, the supervisor uses `:simple_one_for_one` under the hood.
+Tasks have their own specialized Supervisor, the `Task.Supervisor`.  Designed for dynamically created tasks, the supervisor uses `DynamicSupervisor` under the hood.
 
 ### Setup
 
 Including the `Task.Supervisor` is no different than other supervisors:
 
 ```elixir
-import Supervisor.Spec
-
 children = [
-  supervisor(Task.Supervisor, [[name: ExampleApp.TaskSupervisor, restart: :transient]])
+  {Task.Supervisor, name: ExampleApp.TaskSupervisor, restart: :transient}
 ]
 
 {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)

--- a/en/lessons/specifics/ecto.md
+++ b/en/lessons/specifics/ecto.md
@@ -11,6 +11,13 @@ Ecto is an official Elixir project providing a database wrapper and integrated q
 
 ## Setup
 
+Create a new app with a supervision tree:
+
+```shell
+$ mix new example_app --sup
+$ cd example_app
+```
+
 To get started we need to include Ecto and a database adapter in our project's `mix.exs`.  You can find a list of supported database adapters in the [Usage](https://github.com/elixir-lang/ecto/blob/master/README.md#usage) section of the Ecto README.  For our example we'll use PostgreSQL:
 
 ```elixir
@@ -19,12 +26,10 @@ defp deps do
 end
 ```
 
-Now we can add Ecto and our adapter to the application list:
+Then we'll fetch our dependencies using
 
-```elixir
-def application do
-  [applications: [:ecto, :postgrex]]
-end
+```shell
+$ mix deps.get
 ```
 
 ### Repository
@@ -39,19 +44,15 @@ end
 
 ### Supervisor
 
-Once we've created our Repo we need to set up our supervisor tree, which is usually found in `lib/<project name>.ex`.
-
-It is important to note that we set up the Repo as a supervisor with `supervisor/3` and _not_ `worker/3`.  If you generated your app with the `--sup` flag much of this exists already:
+Once we've created our Repo we need to set up our supervisor tree, which is found in `lib/<project name>/application.ex`. Add the Repo to the `children` list:
 
 ```elixir
-defmodule ExampleApp.App do
+defmodule ExampleApp.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      supervisor(ExampleApp.Repo, [])
+      ExampleApp.Repo
     ]
 
     opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]


### PR DESCRIPTION
Addresses #1029 

The Ecto section was easy enough to update, but I expanded a lot on the OTP Supervisors page.  I added a more complete tutorial using the SimpleQueue module to show that the module is automatically started.  I also tried to summarize the new DynamicSupervisor without just copying over the official docs.

Some questions:
1. The project's _config.yml file has the Elixir version set to 1.5.2.  Should that be updated to 1.6 since DynamicSupervisor was added in that version?  Or is that version kept for another reason?

2. I see that the markdown files themselves are versioned to track which files need translations.  I did not increment the version number, what should they be set to with these updates?

3. Any improvements or clarifications?