### PR TITLE
add parens to function call

### DIFF
--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -120,7 +120,7 @@ When we don't want other modules accessing a specific function we can make the f
 
 ```elixir
 defmodule Greeter do
-  def hello(name), do: phrase <> name
+  def hello(name), do: phrase() <> name
   defp phrase, do: "Hello, "
 end
 

--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Functions
 redirect_from:
   - /lessons/basics/functions/


### PR DESCRIPTION
I'm getting this error when running the example:

```
warning: variable "phrase" does not exist and is being expanded to "phrase()", please use parentheses to remove the ambiguity or change the variable name
```

I'm pretty new to Elixir so feel free to judge :)