### PR TITLE
Create redirect pages for old location of English lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ In addition to the steps above there are a few addition steps required for trans
      * if this is a initial lesson translation, the version should be set to `1.0.0`;
      * if you apply the original lesson updates to the translation, the version should be copied from the corresponding state of the original lesson;
      * else bump one of the version numbers depending on how important is your change.
-   * `redirect_from` should be removed since it is used only for English lessons that earlier were hosted in a separate folder without a language prefix.
 
    For example `/ja/lessons/basics/basics.md`:
 

--- a/en/index.md
+++ b/en/index.md
@@ -1,6 +1,5 @@
 ---
 title: Elixir School
-redirect_from: /
 layout: home
 ---
 

--- a/en/lessons/advanced/behaviours.md
+++ b/en/lessons/advanced/behaviours.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Behaviours
-redirect_from:
-  - /lessons/advanced/behaviours/
 ---
 
 We learned about Typespecs in the previous lesson, here we'll learn how to require a module to implement those specifications.  In Elixir, this functionality is referred to as behaviours.

--- a/en/lessons/advanced/concurrency.md
+++ b/en/lessons/advanced/concurrency.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.0
 title: Concurrency
-redirect_from:
-  - /lessons/advanced/concurrency/
 ---
 
 One of the selling points of Elixir is its support for concurrency. Thanks to the Erlang VM (BEAM), concurrency in Elixir is easier than expected.  The concurrency model relies on Actors, a contained process that communicates with other processes through message passing.

--- a/en/lessons/advanced/erlang.md
+++ b/en/lessons/advanced/erlang.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Erlang Interoperability
-redirect_from:
-  - /lessons/advanced/erlang/
 ---
 
 One of the added benefits to building on top of the Erlang VM (BEAM) is the plethora of existing libraries available to us.  Interoperability allows us to leverage those libraries and the Erlang standard lib from our Elixir code.  In this lesson we'll look at how to access functionality in the standard lib along with third-party Erlang packages.

--- a/en/lessons/advanced/error-handling.md
+++ b/en/lessons/advanced/error-handling.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Error Handling
-redirect_from:
-- /lessons/advanced/error-handling/
 ---
 
 Although more common to return the `{:error, reason}` tuple, Elixir supports exceptions and in this lesson we'll look at how to handle errors and the different mechanisms available to us.

--- a/en/lessons/advanced/escripts.md
+++ b/en/lessons/advanced/escripts.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Executables
-redirect_from:
-  - /lessons/advanced/escripts/
 ---
 
 To build executables in Elixir we will be using escript. Escript produces an executable that can be run on any system with Erlang installed.

--- a/en/lessons/advanced/gen-stage.md
+++ b/en/lessons/advanced/gen-stage.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: GenStage
-redirect_from:
-  - /lessons/advanced/gen-stage/
 ---
 
 In this lesson we're going to take a closer look at the GenStage, what role it serves, and how we can leverage it in our applications.

--- a/en/lessons/advanced/metaprogramming.md
+++ b/en/lessons/advanced/metaprogramming.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Metaprogramming
-redirect_from:
-  - /lessons/advanced/metaprogramming/
 ---
 
 Metaprogramming is the process of using code to write code.  In Elixir this gives us the ability to extend the language to fit our needs and dynamically change the code.  We'll start by looking at how Elixir is represented under the hood, then how to modify it, and finally we can use this knowledge to extend it.

--- a/en/lessons/advanced/otp-concurrency.md
+++ b/en/lessons/advanced/otp-concurrency.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: OTP Concurrency
-redirect_from:
-  - /lessons/advanced/otp-concurrency/
 ---
 
 We've looked at the Elixir abstractions for concurrency but sometimes we need greater control and for that we turn to the OTP behaviors that Elixir is built on.

--- a/en/lessons/advanced/otp-supervisors.md
+++ b/en/lessons/advanced/otp-supervisors.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.0
 title: OTP Supervisors
-redirect_from:
-  - /lessons/advanced/otp-supervisors/
 ---
 
 Supervisors are specialized processes with one purpose: monitoring other processes. These supervisors enable us to create fault-tolerant applications by automatically restarting child processes when they fail.

--- a/en/lessons/advanced/protocols.md
+++ b/en/lessons/advanced/protocols.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Protocols
-redirect_from:
-  - /lessons/advanced/protocols/
 ---
 
 In this lesson we are going to look at Protocols, what they are, and how we use them in Elixir.

--- a/en/lessons/advanced/typespec.md
+++ b/en/lessons/advanced/typespec.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Specifications and types
-redirect_from:
-  - /lessons/advanced/typespec/
 ---
 
 In this lesson we will learn about `@spec` and `@type` syntax. `@spec` is more of a syntax complement for writing documentation that could be analyzed by tools. `@type` helps us write more readable and easier to understand code.

--- a/en/lessons/advanced/umbrella-projects.md
+++ b/en/lessons/advanced/umbrella-projects.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Umbrella Projects
-redirect_from:
-  - /lessons/advanced/umbrella-projects/
 ---
 
 Sometimes a project can get big, really big in fact. The Mix build tool allows us to split our code into multiple apps and make our Elixir projects more manageable as they grow.

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.2
 title: Basics
-redirect_from:
-  - /lessons/basics/basics/
 ---
 
 Getting started, basic data types, and basic operations.

--- a/en/lessons/basics/collections.md
+++ b/en/lessons/basics/collections.md
@@ -1,8 +1,6 @@
 ---
 version: 1.2.2
 title: Collections
-redirect_from:
-  - /lessons/basics/collections/
 ---
 
 Lists, tuples, keyword lists, and maps.

--- a/en/lessons/basics/comprehensions.md
+++ b/en/lessons/basics/comprehensions.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.0
 title: Comprehensions
-redirect_from:
-  - /lessons/basics/comprehensions/
 ---
 
 List comprehensions are syntactic sugar for looping through enumerables in Elixir.  In this lesson we'll look at how we can use comprehensions for iteration and generation.

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.1
 title: Control Structures
-redirect_from:
-  - /lessons/basics/control-structures/
 ---
 
 In this lesson we will look at the control structures available to us in Elixir.

--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Documentation
-redirect_from:
-  - /lessons/basics/documentation/
 ---
 
 Documenting Elixir code.

--- a/en/lessons/basics/enum.md
+++ b/en/lessons/basics/enum.md
@@ -1,8 +1,6 @@
 ---
 version: 1.4.0
 title: Enum
-redirect_from:
-  - /lessons/basics/enum/
 ---
 
 A set of algorithms for enumerating over enumerables.

--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Functions
-redirect_from:
-  - /lessons/basics/functions/
 ---
 
 In Elixir and many functional languages, functions are first class citizens.  We will learn about the types of functions in Elixir, what makes them different, and how to use them.

--- a/en/lessons/basics/iex-helpers.md
+++ b/en/lessons/basics/iex-helpers.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: IEx Helpers
-redirect_from:
-  - /lessons/basics/iex-helpers/
 ---
 
 {% include toc.html %}

--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Custom Mix Tasks
-redirect_from:
-  - /lessons/basics/mix-tasks/
 ---
 
 Creating custom Mix tasks for your Elixir projects.

--- a/en/lessons/basics/mix.md
+++ b/en/lessons/basics/mix.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Mix
-redirect_from:
-  - /lessons/basics/mix/
 ---
 
 Before we can dive into the deeper waters of Elixir we first need to learn about Mix. If you're familiar with Ruby, Mix is Bundler, RubyGems, and Rake combined. It's a crucial part of any Elixir project and in this lesson we're going to explore just a few of its great features. To see all that Mix has to offer run `mix help`.

--- a/en/lessons/basics/modules.md
+++ b/en/lessons/basics/modules.md
@@ -1,8 +1,6 @@
 ---
 version: 1.2.0
 title: Modules
-redirect_from:
-  - /lessons/basics/modules/
 ---
 
 We know from experience it's unruly to have all of our functions in the same file and scope.  In this lesson we're going to cover how to group functions and define a specialized map known as a struct in order to organize our code more efficiently.

--- a/en/lessons/basics/pattern-matching.md
+++ b/en/lessons/basics/pattern-matching.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Pattern Matching
-redirect_from:
-  - /lessons/basics/pattern-matching/
 ---
 
 Pattern matching is a powerful part of Elixir.  It allows us to match simple values, data structures, and even functions.  In this lesson we will begin to see how pattern matching is used.

--- a/en/lessons/basics/pipe-operator.md
+++ b/en/lessons/basics/pipe-operator.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Pipe Operator
-redirect_from:
-  - /lessons/basics/pipe-operator/
 ---
 
 The pipe operator `|>` passes the result of an expression as the first parameter of another expression.

--- a/en/lessons/basics/sigils.md
+++ b/en/lessons/basics/sigils.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Sigils
-redirect_from:
-  - /lessons/basics/sigils/
 ---
 
 Working with and creating sigils.

--- a/en/lessons/basics/strings.md
+++ b/en/lessons/basics/strings.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.1
 title: Strings
-redirect_from:
-  - /lessons/basics/strings/
 ---
 
 Strings, Char Lists, Graphemes and Codepoints.

--- a/en/lessons/basics/testing.md
+++ b/en/lessons/basics/testing.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.1
 title: Testing
-redirect_from:
-  - /lessons/basics/testing/
 ---
 
 Testing is an important part of developing software.  In this lesson we'll look at how to test our Elixir code with ExUnit and some best practices for doing so.

--- a/en/lessons/libraries/benchee.md
+++ b/en/lessons/libraries/benchee.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Benchee
-redirect_from:
-  - /lessons/libraries/benchee/
 ---
 
 We can't just guess about which functions are fast and which are slow - we need actual measurements when we're curious. That's where benchmarking comes in. In this lesson, we'll learn about how easy it is to measure the speed of our code.

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Guardian (Basics)
-redirect_from:
-  - /lessons/libraries/guardian/
 ---
 
 [Guardian](https://github.com/ueberauth/guardian) is a widely used authentication library based on [JWT](https://jwt.io/) (JSON Web Tokens).

--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.1
 title: Poolboy
-redirect_from:
-  - /lessons/libraries/poolboy/
 ---
 
 You can easily exhaust your system resources if you do not limit the maximum number of concurrent processes that your program can spawn. [Poolboy](https://github.com/devinus/poolboy) is a widely used lightweight, generic pooling library for Erlang that addresses this issue.

--- a/en/lessons/specifics/debugging.md
+++ b/en/lessons/specifics/debugging.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.1
 title: Debugging
-redirect_from:
-  - /lessons/specifics/debugging/
 ---
 
 Bugs are an inherent part of any project, that's why we need debugging. In this lesson we'll learn about debugging Elixir code as well as static analysis tools to help find potential bugs.

--- a/en/lessons/specifics/ecto.md
+++ b/en/lessons/specifics/ecto.md
@@ -1,8 +1,6 @@
 ---
 version: 1.2.0
 title: Ecto
-redirect_from:
-  - /lessons/specifics/ecto/
 ---
 
 Ecto is an official Elixir project providing a database wrapper and integrated query language.  With Ecto we're able to create migrations, define schemas, insert and update records, and query them.

--- a/en/lessons/specifics/eex.md
+++ b/en/lessons/specifics/eex.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.2
 title: Embedded Elixir (EEx)
-redirect_from:
-  - /lessons/specifics/eex/
 ---
 
 Much like Ruby has ERB and Java has JSPs, Elixir has EEx, or Embedded Elixir.  With EEx we can embed and evaluate Elixir inside strings.

--- a/en/lessons/specifics/ets.md
+++ b/en/lessons/specifics/ets.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.0
 title: Erlang Term Storage (ETS)
-redirect_from:
-  - /lessons/specifics/ets/
 ---
 
 Erlang Term Storage, commonly referred to as ETS, is a powerful storage engine built into OTP and available to use in Elixir.  In this lesson we'll look at how to interface with ETS and how it can be employed in our applications.

--- a/en/lessons/specifics/mnesia.md
+++ b/en/lessons/specifics/mnesia.md
@@ -1,8 +1,6 @@
 ---
 version: 1.0.0
 title: Mnesia
-redirect_from:
-  - /lessons/specifics/mnesia/
 ---
 
 Mnesia is a heavy duty real-time distributed database management system.

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -1,8 +1,6 @@
 ---
 version: 1.1.2
 title: Plug
-redirect_from:
-  - /lessons/specifics/plug/
 ---
 
 If you're familiar with Ruby you can think of Plug as Rack with a splash of Sinatra.

--- a/lessons/advanced/behaviours.md
+++ b/lessons/advanced/behaviours.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/behaviours/
+---

--- a/lessons/advanced/concurrency.md
+++ b/lessons/advanced/concurrency.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/concurrency/
+---

--- a/lessons/advanced/erlang.md
+++ b/lessons/advanced/erlang.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/erlang/
+---

--- a/lessons/advanced/error-handling.md
+++ b/lessons/advanced/error-handling.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/error-handling/
+---

--- a/lessons/advanced/escripts.md
+++ b/lessons/advanced/escripts.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/escripts/
+---

--- a/lessons/advanced/gen-stage.md
+++ b/lessons/advanced/gen-stage.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/gen-stage/
+---

--- a/lessons/advanced/metaprogramming.md
+++ b/lessons/advanced/metaprogramming.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/metaprogramming/
+---

--- a/lessons/advanced/otp-concurrency.md
+++ b/lessons/advanced/otp-concurrency.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/otp-concurrency/
+---

--- a/lessons/advanced/otp-supervisors.md
+++ b/lessons/advanced/otp-supervisors.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/otp-supervisors/
+---

--- a/lessons/advanced/protocols.md
+++ b/lessons/advanced/protocols.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/protocols/
+---

--- a/lessons/advanced/typespec.md
+++ b/lessons/advanced/typespec.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/typespec/
+---

--- a/lessons/advanced/umbrella-projects.md
+++ b/lessons/advanced/umbrella-projects.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/advanced/umbrella-projects/
+---

--- a/lessons/basics/basics.md
+++ b/lessons/basics/basics.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/basics/
+---

--- a/lessons/basics/collections.md
+++ b/lessons/basics/collections.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/collections/
+---

--- a/lessons/basics/comprehensions.md
+++ b/lessons/basics/comprehensions.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/comprehensions/
+---

--- a/lessons/basics/control-structures.md
+++ b/lessons/basics/control-structures.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/control-structures/
+---

--- a/lessons/basics/documentation.md
+++ b/lessons/basics/documentation.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/documentation/
+---

--- a/lessons/basics/enum.md
+++ b/lessons/basics/enum.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/enum/
+---

--- a/lessons/basics/functions.md
+++ b/lessons/basics/functions.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/functions/
+---

--- a/lessons/basics/iex-helpers.md
+++ b/lessons/basics/iex-helpers.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/iex-helpers/
+---

--- a/lessons/basics/mix-tasks.md
+++ b/lessons/basics/mix-tasks.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/mix-tasks/
+---

--- a/lessons/basics/mix.md
+++ b/lessons/basics/mix.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/mix/
+---

--- a/lessons/basics/modules.md
+++ b/lessons/basics/modules.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/modules/
+---

--- a/lessons/basics/pattern-matching.md
+++ b/lessons/basics/pattern-matching.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/pattern-matching/
+---

--- a/lessons/basics/pipe-operator.md
+++ b/lessons/basics/pipe-operator.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/pipe-operator/
+---

--- a/lessons/basics/sigils.md
+++ b/lessons/basics/sigils.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/sigils/
+---

--- a/lessons/basics/strings.md
+++ b/lessons/basics/strings.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/strings/
+---

--- a/lessons/basics/testing.md
+++ b/lessons/basics/testing.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/basics/testing/
+---

--- a/lessons/libraries/benchee.md
+++ b/lessons/libraries/benchee.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/libraries/benchee/
+---

--- a/lessons/libraries/bypass.md
+++ b/lessons/libraries/bypass.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/libraries/bypass/
+---

--- a/lessons/libraries/guardian.md
+++ b/lessons/libraries/guardian.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/libraries/guardian/
+---

--- a/lessons/libraries/poolboy.md
+++ b/lessons/libraries/poolboy.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/libraries/poolboy/
+---

--- a/lessons/specifics/debugging.md
+++ b/lessons/specifics/debugging.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/debugging/
+---

--- a/lessons/specifics/ecto.md
+++ b/lessons/specifics/ecto.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/ecto/
+---

--- a/lessons/specifics/eex.md
+++ b/lessons/specifics/eex.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/eex/
+---

--- a/lessons/specifics/ets.md
+++ b/lessons/specifics/ets.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/ets/
+---

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/mnesia/
+---

--- a/lessons/specifics/plug.md
+++ b/lessons/specifics/plug.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/plug/
+---

--- a/lessons/specifics/registry.md
+++ b/lessons/specifics/registry.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /en/lessons/specifics/registry/
+---


### PR DESCRIPTION
It creates a .md file with the "redirect_to" directive for every lesson,
in order to avoid translators to copy the "redirect_from" directive

Closes #1397

Script for creating the new redirect files

```bash
for d in $( ls -1 en/lessons/ ); do
  mkdir -p lessons/${d}
  for f in $( ls -1 en/lessons/${d}/ | sed -e 's/\..*$//' ); do
    echo -e "---\nredirect_to:\n  - /en/lessons/${d}/${f}/\n---" > lessons/${d}/${f}.md;
  done
done
```