### PR TITLE
Rename Appendix to Blog to clear up confusion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,10 @@
 # Setup
 baseurl: /
 url: https://elixirschool.com
-permalink: /appendix/articles/:title/
+permalink: /blog/articles/:title/
 default_lang: en
 exclude_from_localization: []
-exclude_from_chapters: ['appendix.html', 'contributors.html']
+exclude_from_chapters: ['blog.html', 'contributors.html']
 
 # Author
 author:

--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -10,7 +10,7 @@ sections:
   advanced: الموضوعات المتقدّمة
   specifics: التفاصيل
   libraries: المكتبات
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -10,7 +10,7 @@ sections:
   advanced: За Напреднали
   specifics: Спесифики
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/bn.yml
+++ b/_data/locales/bn.yml
@@ -10,7 +10,7 @@ sections:
   advanced: দক্ষ পর্যায়
   specifics: নিয়মাবলি
   libraries: লাইব্রেরিস
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/cn.yml
+++ b/_data/locales/cn.yml
@@ -10,7 +10,7 @@ sections:
   advanced: 高级
   specifics: 专题
   libraries: 程序库
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Erweitert
   specifics: Einzelheiten
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Advanced
   specifics: Specifics
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Avanzado
   specifics: Específico
   libraries: Librerías
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Avancé
   specifics: Spécificités
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/gr.yml
+++ b/_data/locales/gr.yml
@@ -11,7 +11,7 @@ sections:
   advanced: Προχωρημένα
   specifics: Ιδιαιτερότητες
   libraries: Βιβλιοθήκες
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Αναφορά Μετάφρασης
   

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Lanjutan
   specifics: Khusus
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Avanzato
   specifics: Specifiche
   libraries: Librerie
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -10,7 +10,7 @@ sections:
   advanced: 上級
   specifics: 詳細
   libraries: ライブラリー
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -10,7 +10,7 @@ sections:
   advanced: 심화
   specifics: 활용
   libraries: 라이브러리
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/ms.yml
+++ b/_data/locales/ms.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Lanjutan
   specifics: Khusus
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/no.yml
+++ b/_data/locales/no.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Avansert
   specifics: Detaljer
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Zaawansowane
   specifics: Specyficzne
   libraries: Biblioteki
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Avançado
   specifics: Específico
   libraries: Bibliotecas
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Продвинутый
   specifics: Специфика
   libraries: Библиотеки
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/sk.yml
+++ b/_data/locales/sk.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Pokročilé
   specifics: Špecifiká
   libraries: Knižnice
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/ta.yml
+++ b/_data/locales/ta.yml
@@ -10,7 +10,7 @@ sections:
   advanced: மேம்பட்டவை
   specifics: ப்ரத்யேகமானவை
   libraries: திரட்டுகள்
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -10,7 +10,7 @@ sections:
   advanced: ขั้นสูง
   specifics: เฉพาะทาง
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Gelişmiş
   specifics: Spesifik
   libraries: Libraries
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/tw.yml
+++ b/_data/locales/tw.yml
@@ -10,7 +10,7 @@ sections:
   advanced: 進階
   specifics: 特色
   libraries: 函式庫
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Просунуті
   specifics: Конкретика
   libraries: Бібліотеки
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -10,7 +10,7 @@ sections:
   advanced: Nâng cao
   specifics: Cụ thể
   libraries: Thư viện
-  appendix: Appendix
+  blog: Blog
   contributors: Contributors
   translation_report: Translation Report
 

--- a/_includes/section-home-appendix-posts.html
+++ b/_includes/section-home-appendix-posts.html
@@ -1,14 +1,14 @@
 <!-- Section -->
 <section>
   <header class="major">
-    <h2>Appendix</h2>
+    <h2>Recent Posts</h2>
   </header>
   <div class="posts">
     {% for post in site.posts limit:6 %}
     <article>
       <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
       <p class="post-date">{{ post.date | date_to_string }}</p>
-      {{ post.excerpt | markdownify }} 
+      {{ post.excerpt | markdownify }}
       <ul class="actions">
         <li><a href="{{ post.url }}" class="button{% unless page.disable_transform %} up{%endunless%}">Read more</a></li>
       </ul>

--- a/_includes/section-sidebar-menu.html
+++ b/_includes/section-sidebar-menu.html
@@ -14,7 +14,7 @@
     {% if page.section %}
       {% assign visiting = page.section %}
     {% else %}
-      {% assign visiting = "appendix" %}
+      {% assign visiting = "blog" %}
     {% endif %}
     {% if visiting == section or (visiting == "home" and section == "basics") %}
       {% assign opened = true %}
@@ -43,7 +43,7 @@
     {% endunless %}
   {% endfor %}
     <li>
-      <a href="/appendix/" class="{% unless locale.disable_transform %} up {%endunless%}{% if page.layout == "appendix" or page.layout == "post" %}active{% endif %}">{{ site.data['locales'][language]['sections']['appendix'] }}</a>
+      <a href="/blog/" class="{% unless locale.disable_transform %} up {%endunless%}{% if page.layout == "blog" or page.layout == "post" %}active{% endif %}">{{ site.data['locales'][language]['sections']['blog']}}</a>
     </li>
     {% unless language == 'en' %}
     <li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
 				<div class="inner">
 					<!-- Header -->
 					<header id="header">
-					  <a href="/" class="logo"><strong>Elixir School</strong>{% if page.layout == "appendix" or page.layout == "post" %} {{ site.data['locales']['en']['sections']['appendix']}}{% endif %}</a>
+					  <a href="/" class="logo"><strong>Elixir School</strong>{% if page.layout == "blog" or page.layout == "post" %} {{ site.data['locales']['en']['sections']['blog']}}{% endif %}</a>
 					  {% include share-icons.html %}
 					</header>
 					{{ content }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,5 +2,5 @@
 layout: default
 ---
 {% include section-home-banner.html %}
-{% include section-home-appendix-posts.html %}
+{% include section-home-blog-posts.html %}
 {% include section-pagination.html %}

--- a/appendix.html
+++ b/appendix.html
@@ -1,6 +1,6 @@
 ---
-title: Appendix
-layout: appendix
+title: Blog
+layout: blog
 disable_transform: true
 ---
 <section>
@@ -9,7 +9,7 @@ disable_transform: true
     <article>
       <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
         <p class="post-date">{{ post.date | date_to_string }}</p>
-        {{ post.excerpt | markdownify }} 
+        {{ post.excerpt | markdownify }}
       <ul class="actions">
         <li><a href="{{ post.url }}" class="button{% unless page.disable_transform %} up{%endunless%}">Read more</a></li>
       </ul>


### PR DESCRIPTION
I sure do love naming things but with a project like Elixir School being mindful of non-native speakers is important it appears "Appendix" isn't exactly clear to most visitors so we're going to keep the name but rename references to it "Blog".

Thoughts @elixirschool/developers ?