### PR TITLE
Slightly improve versioning style of the translation report

### DIFF
--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -159,4 +159,16 @@ $version_color_map: (
     background-color: #{$color};
   }
 }
+
+.translation-report {
+
+  .version-difference-indicator {
+    width: 1em;
+    height: 1em;
+  }
+
+  .version-cell {
+    vertical-align: middle;
+  }
+}
 }

--- a/_includes/report.html
+++ b/_includes/report.html
@@ -2,34 +2,36 @@
   <header class="major">
     <h2>{{ site.data['locales'][page['lang']]['sections']['translation_report'] }} - {{ page['translation_report']['percentage'] }}%</h2>
   </header>
-  <div class="contributors">
-<table>
-  <thead>
-    <tr>
-      {% assign headers = page['translation_report']['headers'] %}
-      <th>{{ headers['section'] }}</th>
-      <th>{{ headers['original_title'] }}</th>
-      <th>{{ headers['translation_title'] }}</th>
-      <th>{{ headers['original_version'] }}</th>
-      <th>{{ headers['translation_version'] }}</th>
-      <th>{{ headers['version_severity'] }}</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for section in page['translation_report']['sections'] %}
-      {% assign title = section[0] %}
-      {% for lesson in section[1] %}
+  <table class="translation-report">
+    <thead>
       <tr>
-        <td>{{ site.data['locales'][page['lang']]['sections'][title] }}</td>
-        <td><a href ="/en/lessons/{{title}}/{{lesson[1]['lesson']}}">{{ lesson[1]['lesson'] }}</a></td>
-        <td>{{ lesson[1]['translated_title'] }}</td>
-        <td>{{ lesson[1]['original_version'] }}</td>
-        <td>{{ lesson[1]['translated_version'] }}</td>
-        <td>{{ lesson[1]['version_severity'] }}</td>
-        <td><span class="version-difference-indicator version-difference-{{ lesson[1]['version_severity'] }}">&nbsp;</span></td>
+        {% assign headers = page['translation_report']['headers'] %}
+        <th>{{ headers['section'] }}</th>
+        <th>{{ headers['original_title'] }}</th>
+        <th>{{ headers['translation_title'] }}</th>
+        <th>{{ headers['original_version'] }}</th>
+        <th>{{ headers['translation_version'] }}</th>
+        <th>{{ headers['version_severity'] }}</th>
+        <th></th>
       </tr>
+    </thead>
+    <tbody>
+      {% for section in page['translation_report']['sections'] %}
+        {% assign title = section[0] %}
+        {% for lesson in section[1] %}
+        <tr>
+          <td>{{ site.data['locales'][page['lang']]['sections'][title] }}</td>
+          <td><a href ="/en/lessons/{{title}}/{{lesson[1]['lesson']}}">{{ lesson[1]['lesson'] }}</a></td>
+          <td>{{ lesson[1]['translated_title'] }}</td>
+          <td>{{ lesson[1]['original_version'] }}</td>
+          <td>{{ lesson[1]['translated_version'] }}</td>
+          <td>{{ lesson[1]['version_severity'] }}</td>
+          <td class="version-cell">
+            <div class="version-difference-indicator version-difference-{{ lesson[1]['version_severity'] }}"></div>
+          </td>
+        </tr>
+        {% endfor %}
       {% endfor %}
-    {% endfor %}
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</section>


### PR DESCRIPTION
<details>
<summary>Before:</summary>

![before](https://user-images.githubusercontent.com/5345029/39747208-4528684c-52b5-11e8-8203-ded7474f2409.png)

</details>

<details>
<summary>After:</summary>

![after](https://user-images.githubusercontent.com/5345029/39747212-482c4176-52b5-11e8-96cd-10adf93991de.png)

</details>