### PR TITLE
fixes bogus links to original lessons

### DIFF
--- a/_includes/report.html
+++ b/_includes/report.html
@@ -21,7 +21,7 @@
         {% for lesson in section[1] %}
         <tr>
           <td>{{ site.data['locales'][page['lang']]['sections'][title] }}</td>
-          <td><a href ="/en/lessons/{{title}}/{{lesson[1]['lesson']}}">{{ lesson[1]['lesson'] }}</a></td>
+          <td><a href ="/en/lessons/{{title}}/{{lesson[1]['chapter']}}">{{ lesson[1]['lesson'] }}</a></td>
           <td>{{ lesson[1]['translated_title'] }}</td>
           <td>{{ lesson[1]['original_version'] }}</td>
           <td>{{ lesson[1]['translated_version'] }}</td>

--- a/_plugins/elixir_school/translation_report.rb
+++ b/_plugins/elixir_school/translation_report.rb
@@ -52,6 +52,7 @@ module ElixirSchool
 
             report[section][lesson] = {
               'lesson'             => lesson_content['title'],
+              'chapter'            => lesson_content['chapter'],
               'original_version'   => prettify_version(lesson_content['version']),
               'translated_title'   => translated_value(site, lang, section, lesson, 'title'),
               'translated_version' => prettify_version(translated_value(site, lang, section, lesson, 'version')),


### PR DESCRIPTION
The original links use the title (which is wrong) to link to the original lesson.