### PR TITLE
Fix empty language name on contributors page

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -70,7 +70,7 @@ translators:
     users:
       - devleoper
 
-  - language: no
+  - language: "no"
     users:
       - Devalo
 


### PR DESCRIPTION
Hello guys.

This will fix issue on the contributors page. Not sure how to describe it, so here are the screenshots:

Before:

<img width="186" alt="2018-05-22 18 40 26" src="https://user-images.githubusercontent.com/307982/40373505-b6cde3c4-5def-11e8-894d-4b7231129c8a.png">

After:

<img width="138" alt="2018-05-22 18 40 37" src="https://user-images.githubusercontent.com/307982/40373513-bb50f134-5def-11e8-889a-cb92f8095726.png">

It's related to weird YAML behavior with 'no' and 'yes' words. [Here are details.](https://coderwall.com/p/ex6tla/yes-and-no-in-yaml)