### PR TITLE
Translation reports page: use existing url data

### DIFF
--- a/_includes/report.html
+++ b/_includes/report.html
@@ -21,7 +21,7 @@
         {% for lesson in section[1] %}
         <tr>
           <td>{{ site.data['locales'][page['lang']]['sections'][title] }}</td>
-          <td><a href ="/en/lessons/{{title}}/{{lesson[1]['chapter']}}">{{ lesson[1]['lesson'] }}</a></td>
+          <td><a href ="{{lesson[1]['url']}}">{{ lesson[1]['lesson'] }}</a></td>
           <td>{{ lesson[1]['translated_title'] }}</td>
           <td>{{ lesson[1]['original_version'] }}</td>
           <td>{{ lesson[1]['translated_version'] }}</td>

--- a/_plugins/elixir_school/translation_report.rb
+++ b/_plugins/elixir_school/translation_report.rb
@@ -54,6 +54,7 @@ module ElixirSchool
             report[section][lesson] = {
               'lesson'              => lesson_content['title'],
               'chapter'             => lesson_content['chapter'],
+              'url'                 => lesson_content['url'],
               'original_version'    => prettify_version(lesson_content['version']),
               'translated_title'    => translated_value(site, lang, section, lesson, 'title'),
               'translated_version'  => prettify_version(translated_value(site, lang, section, lesson, 'version')),


### PR DESCRIPTION
At the moment, on the translations page links to lessons work fine, except for homepage link. This is happening due to manual route forming, which is usually not a good thing, as it brings bugs - just like in this case. 😄 

Link looks like this: https://elixirschool.com/en/lessons/home/home and would obviously not work.

Meanwhile, locally after these changes link looks like this: http://localhost:4000/en/ and I haven't yet noticed any degradations.