### PR TITLE
Fix broken markdown in TA translation index page

### DIFF
--- a/ta/index.md
+++ b/ta/index.md
@@ -8,8 +8,9 @@ version: 1.0.0
 
 எலிக்சர் எனும் நிரலாக்கமொழி பற்றிய பாடங்களின் தொகுப்பு. டுவிட்டரின் [ஸ்காலா பள்ளியின்](http://twitter.github.io/scala_school/) தாக்கத்தில் உருவானது.
 
-[English][en] [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe](tr), [ภาษาไทย][th] மற்றும் பலமொழிகளிலும் கற்கலாம்.
+[English][en], [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], [ภาษาไทย][th] மற்றும் பலமொழிகளிலும் கற்கலாம்.
 
+  [en]: /en/
   [cn]: /cn/
   [es]: /es/
   [it]: /it/


### PR DESCRIPTION


Actually, here we've had three problems:

 - Missing link to `en` version, which looked like this:
<img width="141" alt="2018-05-30 00 41 12" src="https://user-images.githubusercontent.com/307982/40687100-2f3b9164-63a2-11e8-9ca2-141de02f7ed4.png">
 - Wrong syntax in `tr` link, which led to link like this: `https://elixirschool.com/ta/tr`
 - Missing comma after `English`

While I know nothing about the language, two first problem seems like this hasn't been proofread, so my assumption is the third one is also a mistake.