### PR TITLE
Improve GenServer definition to state that it's single process

### DIFF
--- a/en/lessons/advanced/otp-concurrency.md
+++ b/en/lessons/advanced/otp-concurrency.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: OTP Concurrency
 redirect_from:
   - /lessons/advanced/otp-concurrency/
@@ -13,7 +13,7 @@ In this lesson we'll focus on the biggest piece: GenServers.
 
 ## GenServer
 
-An OTP server is a module with the GenServer behavior that implements a set of callbacks.  At its most basic level a GenServer is a loop that handles one request per iteration passing along an updated state.
+An OTP server is a module with the GenServer behavior that implements a set of callbacks. At its most basic level a GenServer is a single process which runs loop that handles one message per iteration passing along an updated state.
 
 To demonstrate the GenServer API we'll implement a basic queue to store and retrieve values.
 


### PR DESCRIPTION
Okay, this may be discussable overall, but this may be improvement.

#487 is a source where I took the idea from, and it makes some sense.

Let's discuss if you think that it's a bad change. :)