### PR TITLE
Rewrite require definition in modules lesson

### DIFF
--- a/en/lessons/basics/modules.md
+++ b/en/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.3.0
 title: Modules
 ---
 
@@ -148,7 +148,7 @@ end
 
 ### `import`
 
-If we want to import functions and macros rather than aliasing the module we can use `import/`:
+If we want to import functions rather than aliasing the module we can use `import`:
 
 ```elixir
 iex> last([1, 2, 3])
@@ -193,7 +193,7 @@ import List, only: :macros
 
 ### `require`
 
-Although used less frequently `require/2` is nonetheless important.  Requiring a module ensures that it is compiled and loaded.  This is most useful when we need to access a module's macros:
+You could use `require` to tell Elixir you're going to macros from other module. The slight difference with `import` is that it allows using macros, but not functions from the specified module:
 
 ```elixir
 defmodule Example do


### PR DESCRIPTION
As someone might have noticed, I'm going through old Issues (2016-ish, so if original author wanted to fix this they had plenty of time).

The next one is #586 . I rewrote `require` definition to be somewhat less ambiguous.

Actually, looks like `import` definition was somewhat incorrect before this change:
Official doc: `# Import functions from Foo so they can be called without the `Foo.` prefix` 
Our definition: `want to import functions and macros`