### PR TITLE
last_commit as a link on report

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/bn.yml
+++ b/_data/locales/bn.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/gr.yml
+++ b/_data/locales/gr.yml
@@ -30,3 +30,4 @@ translation_report:
   original_version: Αρχική Έκδοση
   translation_version: Έκδοση Μετάφρασης
   version_severity: Διαφορά Εκδόσεων
+  last_commit: Τελευταία Αλλαγή

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -29,3 +29,4 @@ version_messages:
     original_version: Original Version
     translation_version: Translation Version
     version_severity: Version Severity
+    last_commit: Last Commit

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/ms.yml
+++ b/_data/locales/ms.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/no.yml
+++ b/_data/locales/no.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Versão Original
   translation_version: Versão da Tradução
   version_severity: Severidade da Versão
+  last_commit: Last Commit

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Версия оригинала
   translation_version: Версия перевода
   version_severity: Разница в версиях
+  last_commit: Last Commit

--- a/_data/locales/sk.yml
+++ b/_data/locales/sk.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/ta.yml
+++ b/_data/locales/ta.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Версія оригіналу
   translation_version: Версія перекладу
   version_severity: Ступінь застарілості
+  last_commit: Last Commit

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/zh-hans.yml
+++ b/_data/locales/zh-hans.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_data/locales/zh-hant.yml
+++ b/_data/locales/zh-hant.yml
@@ -29,3 +29,4 @@ translation_report:
   original_version: Original Version
   translation_version: Translation Version
   version_severity: Version Severity
+  last_commit: Last Commit

--- a/_includes/report.html
+++ b/_includes/report.html
@@ -12,6 +12,7 @@
         <th>{{ headers['original_version'] }}</th>
         <th>{{ headers['translation_version'] }}</th>
         <th>{{ headers['version_severity'] }}</th>
+        <th>{{ headers['last_commit'] }}</th>
       </tr>
     </thead>
     <tbody>
@@ -30,6 +31,14 @@
           <td>{{ lesson[1]['translated_version'] }}</td>
           <td class="version-cell" title="{{ lesson[1]['translated_severity'] }}">
             <div class="version-difference-indicator version-difference-{{ lesson[1]['version_severity'] }}"></div>
+          </td>
+          <td>
+              {% if lesson[1]['last_commit'] == '' %}
+              {% else %}
+              <a class="icon fa-github-square" href="{{ lesson[1]['last_commit'] }}">
+                  <span class="label">{{ headers['last_commit'] }}</span>
+              </a>
+              {% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/_plugins/elixir_school/translation_report.rb
+++ b/_plugins/elixir_school/translation_report.rb
@@ -60,7 +60,8 @@ module ElixirSchool
               'translated_title'    => translated_value(site, lang, section, lesson, 'title'),
               'translated_version'  => prettify_version(translated_value(site, lang, section, lesson, 'version')),
               'version_severity'    => severity,
-              'translated_severity' => translated_severity
+              'translated_severity' => translated_severity,
+              'last_commit' => severe?(severity) ? find_last_commit(severity, lesson_content) : ''
             }
         end
       end
@@ -70,6 +71,19 @@ module ElixirSchool
         'sections' => report,
         'percentage' => points_to_percentage(points, total_lessons)
       }
+    end
+
+    def find_last_commit(severity, lesson_content)
+      file = lesson_content["url"].gsub('"', '').gsub(/\/$/, '.md')
+      if file == '/en.md'
+        file = '/en/index.md'
+      end
+      git = `git blame -L 2,2 -- #{Dir.pwd}/#{file}`
+      "https://github.com/elixirschool/elixirschool/commit/#{git[0..7]}"
+    end
+
+    def severe?(severity)
+      severity != "none" && severity != "error"
     end
 
     def prettify_version(version)


### PR DESCRIPTION
This is based on the fact that english lesson has the version on second line. For example, en/index.md breaks it.