### PR TITLE
More transtion updates of Simplified Chinese

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -8,11 +8,10 @@ Elixir School is the premier destination for people looking to learn and master 
 
 Whether you're a seasoned veteran or this is your first time, you'll find what you need in lessons and auxiliary resources.
 
-Through the hard work of volunteers Elixir School has been translated to many languages.  Some of these translations include: [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], and [ภาษาไทย][th].
+Through the hard work of volunteers Elixir School has been translated to many languages.  Some of these translations include: [Việt ngữ][vi], [简体中文][zh-hans], [繁體中文][zh-hant], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], and [ภาษาไทย][th].
 
 We welcome and encourage you to join us in continuing to make Elixir School great by getting in involved at [elixirschool/elixirschool](https://github.com/elixirschool/elixirschool)!
 
-  [cn]: /cn/
   [es]: /es/
   [it]: /it/
   [ja]: /ja/
@@ -29,3 +28,5 @@ We welcome and encourage you to join us in continuing to make Elixir School grea
   [bn]: /bn/
   [tr]: /tr/
   [th]: /th/
+  [zh-hans]: /zh-hans/
+  [zh-hant]: /zh-hant/

--- a/en/lessons/basics/control-structures.md
+++ b/en/lessons/basics/control-structures.md
@@ -80,7 +80,7 @@ iex> case "cherry pie" do
 
 Another neat feature of `case/2` is its support for guard clauses:
 
-_This example comes directly from the official Elixir [Getting Started](http://elixir-lang.org/getting-started/case-cond-and-if.html#case) guide._
+_This example comes directly from the official Elixir [Getting Started](https://elixir-lang.org/getting-started/case-cond-and-if.html#case) guide._
 
 ```elixir
 iex> case {1, 2, 3} do
@@ -98,7 +98,7 @@ Check the official docs for [Expressions allowed in guard clauses](https://hexdo
 
 When we need to match conditions rather than values we can turn to `cond/1`; this is akin to `else if` or `elsif` from other languages:
 
-_This example comes directly from the official Elixir [Getting Started](http://elixir-lang.org/getting-started/case-cond-and-if.html#cond) guide._
+_This example comes directly from the official Elixir [Getting Started](https://elixir-lang.org/getting-started/case-cond-and-if.html#cond) guide._
 
 ```elixir
 iex> cond do

--- a/zh-hans/index.md
+++ b/zh-hans/index.md
@@ -1,22 +1,33 @@
 ---
 title: Elixir School
 layout: home
-version: 1.0.0
+version: 2.0.0
 ---
 
-[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+Elixir School 是希望掌握 Elixir 这门编程语言的人首选资料。
 
-Elixir 基础知识教程，受 Twitter 的 [Scala School](http://twitter.github.io/scala_school/) 启发编写。
+不管你是否有经验，你都一定可以从从这些课程中得到你想要的辅助资料。
 
-_欢迎你的反馈和参与_
+通过无数志愿者的努力，Elixir School 已经本翻译成了多种语言，包括: [Việt ngữ][vi], [简体中文][zh-hans], [繁體中文][zh-hant], [Español][es], [Slovenčina][sk], [日本語][ja], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Indonesia][id], [Bahasa Melayu][ms], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch][de], [বাংলা][bn], [Türkçe][tr], and [ภาษาไทย][th].
 
-# 关于 Elixir
-"Elixir 是一种动态的函数编程语言，用来编写可扩展和易于维护的应用。" --[elixir-lang.org](http://elixir-lang.org/)
 
-Elixir 语言是构建在久经检验的 Erlang VM (BEAM) 之上，可以方便地编写分布式、低延迟和高容错性的系统。
+我们希望并且期待你加入我们一起完善 Elixir School。我们的项目地址是 [elixirschool/elixirschool](https://github.com/elixirschool/elixirschool)。
 
-## 特性
-- 高并发
-- 高容错性
-- 函数式编程
-- 可扩展
+  [es]: /es/
+  [it]: /it/
+  [ja]: /ja/
+  [ko]: /ko/
+  [pl]: /pl/
+  [pt]: /pt/
+  [ru]: /ru/
+  [sk]: /sk/
+  [vi]: /vi/
+  [id]: /id/
+  [ms]: /ms/
+  [uk]: /uk/
+  [de]: /de/
+  [bn]: /bn/
+  [tr]: /tr/
+  [th]: /th/
+  [zh-hans]: /zh-hans/
+  [zh-hant]: /zh-hant/

--- a/zh-hans/lessons/basics/control-structures.md
+++ b/zh-hans/lessons/basics/control-structures.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.1.1
 title: 控制语句
 ---
 
@@ -8,7 +8,8 @@ title: 控制语句
 {% include toc.html %}
 
 ## `if` 和 `unless`
-你之前可能遇到过 `if/2`了，如果你使用过 Ruby，也会很熟悉 `unless`。它们在 Elixir 使用方式也一样，只不过它们在 Elixir 里是宏定义，不是语言本身的语句。你可以在 [Kernel 模块](https://hexdocs.pm/elixir/Kernel.html) 找到它们的实现。
+
+你之前可能遇到过 `if/2`了，如果你使用过 Ruby，也会很熟悉 `unless/2`。它们在 Elixir 使用方式也一样，只不过它们在 Elixir 里是宏定义，不是语言本身的语句。你可以在 [Kernel 模块](https://hexdocs.pm/elixir/Kernel.html) 找到它们的实现。
 
 需要注意的是，Elixir 中唯一为假的值是 `nil` 和 布尔值 `false`。
 
@@ -26,7 +27,7 @@ iex> if "a string value" do
 "Truthy"
 ```
 
-`unless/2` 使用方法和 `if/2` 一样，不过只有当判断为否定才会继续执行：
+`unless/2` 使用方法和 `if/2` 一样，不过只有当判断为否才会继续执行：
 
 ```elixir
 iex> unless is_integer("hello") do
@@ -48,7 +49,7 @@ iex> case {:ok, "Hello World"} do
 "Hello World"
 ```
 
-`_` 变量是 `case` 语句重要的一项，如果没有 `_`，所有模式都无法匹配的时候会抛出异常：
+`_` 变量是 `case/` 语句重要的一项，如果没有 `_`，所有模式都无法匹配的时候会抛出异常：
 
 ```elixir
 iex> case :even do
@@ -63,11 +64,13 @@ iex> case :even do
 "Not Odd"
 ```
 
-可以把 `_` 想象成最后的 `else`，会匹配任何东西。因为 `case` 依赖模式匹配，所以之前所有的规则和限制在这里都适用。
-如果你想匹配已经定义的变量，一定要使用 pin 操作符 `^`：
+可以把 `_` 想象成最后的 `else`，会匹配任何东西。
+
+因为 `case/2` 依赖模式匹配，所以之前所有的有关模式匹配的规则和限制在这里都适用。
+如果你想匹配已经定义的变量，一定要使用 pin 操作符 `^/1`：
 
 ```elixir
-iex> pie = 3.14 
+iex> pie = 3.14
  3.14
 iex> case "cherry pie" do
 ...>   ^pie -> "Not so tasty"
@@ -76,9 +79,9 @@ iex> case "cherry pie" do
 "I bet cherry pie is tasty"
 ```
 
-`case` 还有一个很酷的特性：它支持卫兵表达式：
+`case/2` 还有一个很酷的特性：它支持卫兵表达式（Guard Clause）：
 
-_这个例子直接取自 Elixir 官方指南的[上手教程](http://elixir-lang.org/getting-started/case-cond-and-if.html#case)_
+_这个例子直接取自 Elixir 官方指南的[上手教程](https://elixir-lang.org/getting-started/case-cond-and-if.html#case)_
 
 ```elixir
 iex> case {1, 2, 3} do
@@ -93,9 +96,10 @@ iex> case {1, 2, 3} do
 参考官方的文档来看[卫兵支持的表达式](https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions)
 
 ## `cond`
-当我们需要匹配条件而不是值的时候，可以使用 `cond`，这和其他语言的 `else if` 或者 `elsif` 相似：
 
-_这个例子直接取自 Elixir 官方教程的 [上手指南](http://elixir-lang.org/getting-started/case-cond-and-if.html#cond)_
+当我们需要匹配条件而不是值的时候，可以使用 `cond/1`，这和其他语言的 `else if` 或者 `elsif` 相似：
+
+_这个例子直接取自 Elixir 官方教程的 [上手指南](https://elixir-lang.org/getting-started/case-cond-and-if.html#cond)_
 
 ```elixir
 iex> cond do
@@ -109,7 +113,7 @@ iex> cond do
 "But this will"
 ```
 
-和 `case` 一样，`cond` 语句如果没有任何匹配会抛出异常。我们可以定义一个 `true` 的条件放到最后，来处理这种意外：
+和 `case/2` 一样，`cond/1` 语句如果没有任何匹配会抛出异常。我们可以定义一个 `true` 的条件放到最后，来处理这种意外：
 
 ```elixir
 iex> cond do

--- a/zh-hans/lessons/basics/pattern-matching.md
+++ b/zh-hans/lessons/basics/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.2
 title: 模式匹配
 ---
 
@@ -10,7 +10,7 @@ title: 模式匹配
 匹配操作符
 ----------
 
-做好心理准备了吗？Elixir 中，`=` 操作符就是我们的匹配操作符。通过这个匹配操作符，我们可以赋值和匹配值，我们来看一下：
+做好心理准备了吗？ Elixir 中，`=` 操作符就是我们的匹配操作符，跟代数里面的等号类似。在 Elixir 当中，用 `=` 来使得左右两边的值相等。如果匹配成功，即左右值相等后，返回这个等式的值。如果两边的值无法匹配，Elixir 则会抛出错误。 我们来看几个例子：
 
 ```elixir
 iex> x = 1
@@ -57,7 +57,7 @@ Pin 操作符
 
 我们刚学到，当匹配的左边包含变量的时候，匹配操作符同时会做赋值操作。有些时候，这种行为并不是预期的，这种情况下，我们可以使用 `^` 操作符。
 
-_这个例子直接取自 Elixir 的[官方指南](http://elixir-lang.org/getting-started/pattern-matching.html)_。
+使用 pin 操作符，我们就是用已经绑定的值去匹配，而不是重新绑定一个新值，让我们来看一下 pin 操作符是怎么工作的吧：
 
 ```elixir
 iex> x = 1
@@ -69,3 +69,36 @@ iex> {x, ^x} = {2, 1}
 iex> x
 2
 ```
+
+Elixir 1.2 开始支持对映射（Map）中的键（Key）以及匹配函数子句（function clause）：
+
+```elixir
+iex> key = "hello"
+"hello"
+iex> %{^key => value} = %{"hello" => "world"}
+%{"hello" => "world"}
+iex> value
+"world"
+iex> %{^key => value} = %{:hello => "world"}
+** (MatchError) no match of right hand side value: %{hello: "world"}
+```
+
+下面是在函数子句中应用 pin 操作符的例子：
+
+```elixir
+iex> greeting = "Hello"
+"Hello"
+iex> greet = fn
+...>   (^greeting, name) -> "Hi #{name}"
+...>   (greeting, name) -> "#{greeting}, #{name}"
+...> end
+#Function<12.54118792/2 in :erl_eval.expr/5>
+iex> greet.("Hello", "Sean")
+"Hi Sean"
+iex> greet.("Mornin'", "Sean")
+"Mornin', Sean"
+iex> greeting
+"Hello"
+```
+
+在上面的例子中，对 `greeting` 重新赋值只是发生在函数里面，函数体以外，`greeting` 的值一直是 `"Hello"`，不会因为函数调用而改变。


### PR DESCRIPTION
Follow ups of #1485

Changes:

1. Updated the pattern-matching lession
2. Updated the Elixir Home
3. Fix the translation links to include Simplified Chinese (zh-hans) and Traditional Chinese (zh-hant)