### PR TITLE
update ecto lesson

### DIFF
--- a/en/lessons/specifics/ecto.md
+++ b/en/lessons/specifics/ecto.md
@@ -142,8 +142,8 @@ defmodule ExampleApp.User do
     timestamps
   end
 
-  @required_fields ~w(username encrypted_password email)
-  @optional_fields ~w()
+  @required_fields ~w(username encrypted_password email)a
+  @optional_fields ~w()a
 
   def changeset(user, params \\ :empty) do
     user


### PR DESCRIPTION
add 'a' to end of 
@required_fields ~w(username encrypted_password email)
and
@optional_fields ~w()
lines. Without it validate_required(@required_fields) throw error: " expects field names to be atoms, got: " string name of field.