### PR TITLE
[fr] Update basics.pattern-matching lesson to 1.0.2

### DIFF
--- a/fr/lessons/basics/pattern-matching.md
+++ b/fr/lessons/basics/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.2
 title: Pattern Matching
 ---
 


### PR DESCRIPTION
After careful rereading, only the version number was to change, seems weird to me but that's the case. Actually spent more time on this one trying to find where I might have missed something, because there was a major version change but ... nope, still good :)