### PR TITLE
add localized homepage links

### DIFF
--- a/_includes/section-sidebar-menu.html
+++ b/_includes/section-sidebar-menu.html
@@ -7,7 +7,9 @@
   </header>
   <span>Elixir {{site.elixir.version}} - Erlang/OTP {{site.erlang.OTP}} [erts-{{site.erlang.erts}}]</span>
   <ul>
-
+    <li>
+      <a href="/{% if page.lang %}{{ page.lang }}/{% endif %}" class="{% unless locale.disable_transform %} up {%endunless%}{% if page.layout == "home" %}active{% endif %}">{{ site.data['locales'][language]['sections']['home'] }}</a>
+    </li>
   {% for sections in site.contents[language] %}
     {% assign section = sections[0] | strip %}
     {% assign chapters = sections[1] %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
 				<div class="inner">
 					<!-- Header -->
 					<header id="header">
-					  <a href="/" class="logo"><strong>Elixir School</strong>{% if page.layout == "blog" or page.layout == "post" %} {{ site.data['locales']['en']['sections']['blog']}}{% endif %}</a>
+					  <a href="/{% if page.lang %}{{ page.lang }}/{% endif %}" class="logo"><strong>Elixir School</strong>{% if page.layout == "blog" or page.layout == "post" %} {{ site.data['locales']['en']['sections']['blog']}}{% endif %}</a>
 					  {% include share-icons.html %}
 					</header>
 					{{ content }}


### PR DESCRIPTION
1. Changed "Elixir School" in the header to link to the respective localized home page (e.g. `href="/ja/`) instead of simply `href="/"`.
2. Adapted the "Menu" heading in the sidebar into an "Elixir School" link to the localized home page. (As the sidebar is a ToC, a homepage link should definitely be on there, but one is currently missing. The "Menu" heading, meanwhile, is entirely superfluous but also perfectly positioned and styled as a title / homepage link. 😄)