### PR TITLE
Refactor contributors.yml

### DIFF
--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -53,6 +53,42 @@
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600,400italic,600italic|Roboto+Slab:400,700');
 
+.profile {
+  h2 {
+    margin: 0 0 .5em 0;
+  }
+
+  .content {
+    margin: 0 0 .5em 0;
+  }
+
+  img {
+    border-radius: _size(border-radius);
+    border: 0;
+  }
+
+  @include breakpoint(small) {
+    h2 {
+      text-align: center;
+    }
+
+    .icons {
+      text-align: center;
+
+      li {
+        display: inline-block;
+        float: none;
+      }
+    }
+
+    img {
+	    display: block;
+	    margin-left: auto;
+	    margin-right: auto;
+	  }
+  }
+}
+
 section .content {
   h2{
     border-bottom: solid 3px _purple(fg-hov);
@@ -62,9 +98,9 @@ section .content {
   }
 }
 
-pre {     
+pre {
   white-space: pre-wrap;
-  word-wrap: break-word; 
+  word-wrap: break-word;
 }
 
 .post-date {
@@ -76,101 +112,102 @@ pre {
   /**
    * Right-to-left languages
    */
-&.rtl {
-  direction: rtl;
-  unicode-bidi: embed;
-}
-
-&.rtl ul > li {
-  margin-right: 10px;
-}
-
-&.rtl pre {
-  direction: ltr;
-  text-align: left;
-}
-
-&.rtl .content {
-  margin-right: auto;
-}
-
-.clickable-header {
-  display: inline-block;
-  cursor: pointer;
-}
-
-.back-to-top {
-  display: inline;
-  cursor: pointer;
-  padding: 0px 1em;
-  color: #ddd;
-
-  &::after {
-    content: '\A';
-    white-space: pre;
-  }
-}
-
-img{
-  max-width: 100%;
-}
-
-/**
- * Versioning
- */
-
-.page-title {
-  display: inline-flex;
-  align-items: center;
-}
-
-.version-difference-indicator {
-  width: 0.5em;
-  height: 0.5em;
-  margin: 0 0.25em;
-  border-radius: 50%;
-}
-
-.version-info {
-  width: 100%;
-  font-size: 0.75em;
-  margin-bottom: 0.75em;
-  padding: 0.5em;
-  border: 1px solid transparent;
-  cursor: pointer;
-}
-
-$version_color_map: (
-"major": "#f00",
-"minor": "#f60",
-"patch": "#fc3",
-"none": "#9f0",
-"error": "#f00",
-"missing": "#f00",
-);
-
-@each $severity, $color in $version_color_map {
-
-  .version-info-#{$severity} {
-    border-color: #{$color};
+  &.rtl {
+    direction: rtl;
+    unicode-bidi: embed;
   }
 
-  .version-difference-#{$severity} {
-    background-color: #{$color};
+  &.rtl ul > li {
+    margin-right: 10px;
   }
-}
 
-.translation-report {
+  &.rtl pre {
+    direction: ltr;
+    text-align: left;
+  }
+
+  &.rtl .content {
+    margin-right: auto;
+  }
+
+  .clickable-header {
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  .back-to-top {
+    display: inline;
+    cursor: pointer;
+    padding: 0px 1em;
+    color: #ddd;
+
+    &::after {
+      content: '\A';
+      white-space: pre;
+    }
+  }
+
+  img{
+    max-width: 100%;
+  }
+
+
+  /**
+   * Versioning
+   */
+
+  .page-title {
+    display: inline-flex;
+    align-items: center;
+  }
 
   .version-difference-indicator {
-    width: 1em;
-    height: 1em;
-    margin: auto;
+    width: 0.5em;
+    height: 0.5em;
+    margin: 0 0.25em;
+    border-radius: 50%;
   }
 
-  .version-cell {
-    vertical-align: middle;
-    cursor: help;
+  .version-info {
+    width: 100%;
+    font-size: 0.75em;
+    margin-bottom: 0.75em;
+    padding: 0.5em;
+    border: 1px solid transparent;
+    cursor: pointer;
   }
-}
+
+  $version_color_map: (
+  "major": "#f00",
+  "minor": "#f60",
+  "patch": "#fc3",
+  "none": "#9f0",
+  "error": "#f00",
+  "missing": "#f00",
+  );
+
+  @each $severity, $color in $version_color_map {
+
+    .version-info-#{$severity} {
+      border-color: #{$color};
+    }
+
+    .version-difference-#{$severity} {
+      background-color: #{$color};
+    }
+  }
+
+  .translation-report {
+
+    .version-difference-indicator {
+      width: 1em;
+      height: 1em;
+      margin: auto;
+    }
+
+    .version-cell {
+      vertical-align: middle;
+      cursor: help;
+    }
+  }
 }

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,110 +1,352 @@
-authors:
-  - username: doomspork
-    lessons: Project creator
-  - username: ybur-yug
-    lessons: IEx Helpers, Protocols
-  - username: Koziolek
-    lessons: Debugging
-  - username: devonestes
-    lessons: Benchee
-  - username: hassox
-    lessons: Guardian
+# INSTRUCTIONS
+# add your github profile, and contributions. See details below.
+#
+# github: (required), name:, twitter:, homepage:, intro:
+# contributions: lesson, blog, translation, developer (required)
+# lessons: list contributed lesson names (required if applicable)
+# articles: list of titles from contributed blog articles (required if applicable)
+# translations: list of locales translated (required if applicable)
 
-developers:
-  - doomspork
-  - nscyclone
-  - Koziolek
-  - burden
-  - eksperimental
+- github: doomspork
+  name: Sean Callan
+  intro:
+  twitter: doomspork
+  homepage: https://seancallan.com
+  contributions:
+    - lesson
+    - developer
+    - blog
+  lessons: ['Project creator']
+  articles:
+    - A look at Elixir 1.6
+    - Just the beginning
+    - Configuration Demystified
+    - Ecto query composition
 
-translators:
-  - language: bg
-    users:
-      - merkata
+- github: ybur-yug
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - lesson
+  lessons:
+    - IEx Helpers
+    - Protocols
 
-  - language: bn
-    users:
-      - masnun
+- github: Koziolek
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - lesson
+    - translator
+    - developer
+  languages:
+    - pl
+  lessons:
+    - Debugging
 
-  - language: zh-hans
-    users:
-      - cizixs
+- github: devonestes
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - lesson
+  lessons:
+    - Benchee
 
-  - language: zh-hant
-    users:
-      - lithiumpie
-      - cizixs
+- github: hassox
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - lesson
+  lessons:
+    - Guardian
 
-  - language: de
-    users:
-      - Lechindianer
+- github: nscyclone
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - developer
+    - translator
+  languages:
+    - ru
 
-  - language: es
-    users:
-      - erickgnavar
-      - milmazz
+- github: burden
+  name: burden
+  intro:
+  homepage: https://burden.cc
+  twitter: cheapexcitement
+  contributions:
+    - developer
 
-  - language: fr
-    users:
-      - julienXX
+- github: eksperimental
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - developer
 
-  - language: gr
-    users:
-      - gemantzu
+- github: masnun
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - bn
 
-  - language: id
-    users:
-      - rezaprima
+- github: merkata
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - bg
 
-  - language: it
-    users:
-      - lucidstack
+- github: cizixs
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - zh-hant
+    - zh-hans
 
-  - language: ja
-    users:
-      - 3100
-      - marocchino
-      - riseshia
+- github: julienXX
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - fr
 
-  - language: ko
-    users:
-      - devleoper
+- github: Lechindianer
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - de
 
-  - language: "no"
-    users:
-      - Devalo
+- github: gemantzu
+  name: George Mantzouranis
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+    - blog
+  languages:
+    - gr
+  articles:
+    - Reviewing Elixir in Action, Second Edition
+    - Reviewing Functional Web Development with Elixir, OTP, and Phoenix
 
-  - language: pl
-    users:
-      - Koziolek
+- github: rezaprima
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - id
 
-  - language: ru
-    users:
-      - brain-geek
-      - nscyclone
+- github: 3100
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ja
 
-  - language: sk
-    users:
-      - michalvalasek
+- github: marocchino
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ja
 
-  - language: ta
-    users:
-      - kalarani
+- github: riseshia
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ja
 
-  - language: th
-    users:
-      - iboss-ptk
+- github: lucidstack
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - it
 
-  - language: tr
-    users:
-      - ismailunal
-      - yasinyaman
+- github: devleoper
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ko
 
-  - language: uk
-    users:
-      - brain-geek
-      - doroshenkoss
+- github: Devalo
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - "no"
 
-  - language: vi
-    users:
-      - joneslee85
+- github: brain-geek
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ru
+    - uk
+
+- github: michalvalasek
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - sk
+
+- github: erickgnavar
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - es
+
+- github: milmazz
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - es
+
+- github: kalarani
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - ta
+
+- github: iboss-ptk
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - th
+
+- github: lithiumpie
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - zh-hant
+
+- github: ismailunal
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - tr
+
+- github: yasinyaman
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - tr
+
+- github: doroshenkoss
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - uk
+
+- github: joneslee85
+  name:
+  intro:
+  homepage:
+  twitter:
+  contributions:
+    - translator
+  languages:
+    - vi
+
+- github: notactuallypagemcconnell
+  intro:
+  homepage:
+  twitter:
+  name: Bobby Grayson
+  contributions:
+    - blog
+  articles:
+    - Agnostic Version Management With asdf

--- a/_includes/contributor-profile.html
+++ b/_includes/contributor-profile.html
@@ -1,0 +1,22 @@
+<div class="row profile">
+  <div class="1u 2u(medium) 12u$(small)"><img src="https://github.com/{{ contributor.github }}.png" alt="" style="max-width: 60px;"></div>
+  <div class="11u 10u(medium) 12u$(small)">
+    <h2>
+    {% if include.contributor.name %}
+      <a href="https://github.com/{{ include.contributor.github }}">{{include.contributor.name}}</a>
+    {% else %}
+      <a href="https://github.com/{{ include.contributor.github }}">@{{include.contributor.github}}</a>
+    {% endif %}
+    </h2>
+    <p class="content">{{ include.contributor.intro }}</p>
+    <ul class="icons">
+      {% if include.contributor.homepage %}
+      <li><a href="{{ include.contributor.homepage }}" class="icon fa-globe"><span class="label">Homepage</span></a></li>
+      {% endif %}
+      {% if include.contributor.twitter %}
+      <li><a href="https://twitter.com/{{ include.contributor.twitter }}" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
+      {% endif %}
+      <li><a href="https://github.com/{{ include.contributor.github }}" class="icon fa-github"><span class="label">Github</span></a></li>
+    </ul>
+  </div>
+</div>

--- a/_includes/function-getArticle.html
+++ b/_includes/function-getArticle.html
@@ -1,0 +1,5 @@
+{% for article in site.posts %}
+  {% if article.title == include.article %}
+    {% assign post = article %}
+  {% endif %}
+{% endfor %}

--- a/contributors.html
+++ b/contributors.html
@@ -8,36 +8,39 @@ disable_transform: true
 
   - contributors are ordered by date of first commit.
 -->
-
-<section>
-  <header class="major">
-    <h2>Contributors</h2>
+<section id="section-page">
+  <header class="main">
+    <h1>Contributors</h1>
   </header>
-  <div class="contributors">
-    <h4>Lesson Authors</h4>
-    <ul>
-      {% for author in site.data.contributors['authors'] %}
-        <li><a href="https://github.com/{{author.username}}">{{author.username}}</a> ({{author.lessons}})</li>
+  <p class="content"><span style="font-weight: 600">Calling all contributors:</span> if you've been missed, now's your chance to get the recognition you deserve. Add your Github profile to the <a href="https://github.com/elixirschool/elixirschool/edit/master/_data/contributors.yml" target="_blank">list of contributors</a>.</p>
+  {% for contributor in site.data.contributors %}
+    <div class="box">
+      {% include contributor-profile.html contributor=contributor %}
+      {% for contribution in contributor.contributions %}
+        {% unless contribution == "developer" %}
+          <div class="box contributor">
+            {% if contribution == "lesson" %}
+              <h4>Lessons</h4>
+              <ul>
+              {% for lesson in contributor.lessons %}<li>{{ lesson }}</li>{% endfor %}
+              </ul>
+            {% endif %}
+            {% if contribution == "blog" %}
+              <h4>Articles</h4>
+              <ul>
+                {% for article in contributor.articles %}<li>{% include function-getArticle.html article=article %}<a href="{{ post.url }}">{{ post.title }}</a></li>{% endfor %}
+              </ul>
+            {% endif %}
+            {% if contribution == "translator" %}
+              <h4>Translations</h4>
+              <ul>
+                {% for language in contributor.languages %}<li><a href="/{{language}}/lessons/basics/basics">{{ site.data.locales['en'].interlang[language] }}</a></li>{% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        {% endunless %}
       {% endfor %}
-    </ul>
+    </div>
+  {% endfor %}
 
-    <h4>Developers</h4>
-    <ul>
-      {% for developer in site.data.contributors['developers'] %}
-        <li><a href="https://github.com/{{developer}}">{{developer}}</a></li>
-      {% endfor %}
- 
-    </ul>
-
-    <h4>Translators</h4>
-    {% for translation in site.data.contributors['translators'] %}
-      <b>{{ site.data.locales['en'].interlang[translation.language] }}</b>
-      <ul>
-      {% for translator in translation.users %}
-        <li><a href="https://github.com/{{translator}}">{{translator}}</a></li>
-      {% endfor %}
-      </ul>
-    {% endfor %}
-
-  </div>
 </section>


### PR DESCRIPTION
In the spirit of Hacktoberfest, I figured that I'd spruce up the contributors page. Feedback and suggestions are welcome.

- refactored contributors.yml - this change is meant to bundle contributions into individual contributor blocks for easier management.
- changed contributors.html - contributors are now displayed like a profile with links to contributions in most cases.

### Desktop
![es-contributors-desktop](https://user-images.githubusercontent.com/73517/46785648-3e53ef80-cce7-11e8-8104-7bdeb2503c81.gif)

### Mobile
![es-contributors-mobile](https://user-images.githubusercontent.com/73517/46785367-655df180-cce6-11e8-8d59-25ce780d8d83.gif)