### PR TITLE
fix dark mode sidebar border inconsistency

### DIFF
--- a/_assets/stylesheets/dark.scss
+++ b/_assets/stylesheets/dark.scss
@@ -174,7 +174,7 @@ body.dark {
     }
     > ul {
       > li {
-        border-top: 1px solid _dark(border);
+        border-color: _dark(border);
         > ul {
           color: _dark(fg);
           a, span {


### PR DESCRIPTION
The new dark mode has a small, assumingly inadvertent, inconsistency of adding a border-top to the first sidebar menu listing. (the regular theme [specifically has a rule removing this border](https://github.com/elixirschool/elixirschool/blob/master/_assets/stylesheets/layout/_menu.scss#L96-L100))

**Current light:**
![2018-10-22 13_47_40-elixir school](https://user-images.githubusercontent.com/7574985/47318563-3e19f500-d601-11e8-81db-d4dd9a1506f2.png)
**Current dark:**
![2018-10-22 13_48_04-elixir school](https://user-images.githubusercontent.com/7574985/47318565-3eb28b80-d601-11e8-8a26-46770ae0cb62.png)
**Dark with change:**
![2018-10-22 13_48_17-elixir school](https://user-images.githubusercontent.com/7574985/47318570-3fe3b880-d601-11e8-818a-2ad59c145277.png)
