### PR TITLE
Quote string to resolve warning

### DIFF
--- a/_posts/2018-10-23-umbrellas-just-when-it-rains.md
+++ b/_posts/2018-10-23-umbrellas-just-when-it-rains.md
@@ -4,7 +4,7 @@ author_link: https://github.com/doomspork
 categories: general
 date: 2018-10-23
 ayout: post
-title: Umbrellas: only when it rains?
+title: 'Umbrellas: only when it rains?'
 excerpt: >
   A look at umbrella applications and how they can help us write cleaner maintainable code.
 ---


### PR DESCRIPTION
Small change.  Realized running locally it does not care for the `:` in the title.