### PR TITLE
Bump elixir / erlang versions to latest stable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,11 +48,11 @@ sitemap:
   priority_name: 'priority'
 
 elixir:
-  version: 1.5.2
+  version: 1.7.3
 
 erlang:
-  OTP: 20
-  erts: 9.1
+  OTP: 21.1
+  erts: 10.1
 
 defaults:
   -


### PR DESCRIPTION
Should we make a plugin to pull this automatically from somewhere or leave it on manual as it is?