### PR TITLE
remove incorrect baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 # Setup
-baseurl: /
 url: https://elixirschool.com
 permalink: /blog/:title/
 default_lang: en


### PR DESCRIPTION
This PR fixes #1564

Turns out we had an incorrect `baseurl` setting in `_config.yml`. I made the decision to just remove the setting because we are accepting Jekyll's default value (which is just an empty string). 