### PR TITLE
Clarify frontpage language to note that right side entries are of the blog

### DIFF
--- a/_includes/section-home-blog-posts.html
+++ b/_includes/section-home-blog-posts.html
@@ -1,7 +1,7 @@
 <!-- Section -->
 <section>
   <header class="major">
-    <h2>Recent Posts</h2>
+    <h2>Blog</h2>
   </header>
   <div class="posts">
     {% for post in site.posts limit:6 %}


### PR DESCRIPTION
Right now, if a new visitor comes it reads 'Recent Posts`juxtaposed with the book content of the left side once opening the index.
It is clear this is reference material present and to be consumed, but what is the right side and lower?
We do not translate blog entries at this time, we do concentrate on the book-style-content for obvious reasons.
This makes the boundary more clear.