### PR TITLE
Fix table headers' text color in dark theme

### DIFF
--- a/_assets/stylesheets/dark.scss
+++ b/_assets/stylesheets/dark.scss
@@ -7,9 +7,8 @@ body.dark {
     color: _dark(fg);
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1, h2, h3, h4, h5, h6, th {
     color: _dark(fg-bold);
-
   }
 
   a {
@@ -86,7 +85,7 @@ body.dark {
       color: #800080;
     }
 
-    .na, .no, .nv, .vc, .vg, .vi,  {
+    .na, .no, .nv, .vc, .vg, .vi  {
       color: lighten(#008080, 20%);
     }
 


### PR DESCRIPTION
<details>
<summary>Table headers are invisible in dark theme:</summary>

![Animation representing the problem](https://user-images.githubusercontent.com/5345029/47419834-b7daeb80-d785-11e8-9e33-5d52bb927b67.gif)

</details>
