### PR TITLE
Add Plug.ErrorHandler to Plug Lesson

### DIFF
--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -109,7 +109,7 @@ defmodule Example.Application do
 end
 ```
 
->Note: We do not have to call `child_spec` here, this function will be called by the supervisor starting this process. We simply pass a tuple with the module that we want the child spec built for and then the three options needed.
+_Note_: We do not have to call `child_spec` here, this function will be called by the supervisor starting this process. We simply pass a tuple with the module that we want the child spec built for and then the three options needed.
 
 This starts up a Cowboy2 server under our app's supervision tree. It starts Cowboy running under the HTTP scheme (you can also specify HTTPS), on the given port, `8080`, specifying the plug, `Example.HelloWorldPlug`, as the interface for any incoming web requests.
 

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -211,13 +211,13 @@ defmodule Example.Plug.VerifyRequest do
   def init(options), do: options
 
   def call(%Plug.Conn{request_path: path} = conn, opts) do
-    if path in opts[:paths], do: verify_request!(conn.body_params, opts[:fields])
+    if path in opts[:paths], do: verify_request!(conn.params, opts[:fields])
     conn
   end
 
-  defp verify_request!(body_params, fields) do
+  defp verify_request!(params, fields) do
     verified =
-      body_params
+      params
       |> Map.keys()
       |> contains_fields?(fields)
 
@@ -262,7 +262,7 @@ defmodule Example.Router do
   plug(:dispatch)
 
   get("/", do: send_resp(conn, 200, "Welcome\n"))
-  post("/upload", do: send_resp(conn, 201, "Uploaded\n"))
+  get("/upload", do: send_resp(conn, 201, "Uploaded\n"))
   match(_, do: send_resp(conn, 404, "Oops!\n"))
 end
 ```
@@ -279,6 +279,9 @@ plug(
 We automatically invoke `VerifyRequest.init(fields: ["content", "mimetype"],
 paths: ["/upload"])`. This in turn passes the given options to the `VerifyRequest.call(conn, opts)` function.
 
+Let's take a look at this plug in action! Go ahead and crash your local server (rember, that's done by pressing `ctrl + c` twice). Then restart the server (`mix run --no-halt`).
+Now go to `127.0.0.1:8080/upload` in your browser and you'll see that the page simply isn't working. We're not even getting our 'Oops!' message. Now let's add our required params by going to `127.0.0.1:8080/upload?content=thing1&mimetype=thing2`. Now we should see our 'Uploaded' message.
+It's not great that when we throw an error we don't get _any_ page, but we'll deal with how to handle errors with plugs later.
 
 ## Making The HTTP Port Configurable
 

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -80,7 +80,7 @@ It receives a `%Plug.Conn{}` connection struct as its first argument and is expe
 
 We need to tell our application to start up and supervise the Cowboy web server when the app starts up.
 
-We'll do so with the [`Plug.Cowboy.child_spec/1`](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html#child_spec/1) function.
+We'll do so with the [`Plug.Adapters.Cowboy.child_spec/1`](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html#child_spec/1) function.
 
 This function expects three options:
 
@@ -108,6 +108,8 @@ defmodule Example.Application do
   end
 end
 ```
+
+>Note: We do not have to call `child_spec` here, this function will be called by the supervisor starting this process. We simply pass a tuple with the module that we want the child spec built for and then the three options needed.
 
 This starts up a Cowboy2 server under our app's supervision tree. It starts Cowboy running under the HTTP scheme (you can also specify HTTPS), on the given port, `8080`, specifying the plug, `Example.HelloWorldPlug`, as the interface for any incoming web requests.
 
@@ -166,7 +168,7 @@ Swap out the `Example.HelloWorldPlug` plug with the new router:
 ```elixir
 def start(_type, _args) do
   children = [
-    Plug.Adapters.Cowboy.child_spec(:http, Example.Router, [], port: 8080)
+    {Plug.Cowboy, scheme: :http, plug: Example.Router, options: [port: 8080]}
   ]
 
   Logger.info("Started application")
@@ -301,7 +303,7 @@ defmodule Example do
   def start(_type, _args) do
 
     children = [
-      Plug.Adapters.Cowboy.child_spec(:http, Example.Router, [], port: cowboy_port())
+      {Plug.Cowboy, scheme: :http, plug: Example.Router, options: [port: cowboy_port()]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -293,10 +293,10 @@ use Mix.config
 config :example, cowboy_port: 8080
 ```
 
-Next we need to update `lib/example.ex` read the port configuration value, and pass it to Cowboy. We'll define a private function to wrap up that responsibility
+Next we need to update `lib/example/application.ex` read the port configuration value, and pass it to Cowboy. We'll define a private function to wrap up that responsibility
 
 ```elixir
-defmodule Example do
+defmodule Example.Application do
   use Application
   defp cowboy_port, do: Application.get_env(:example, :cowboy_port, 8080)
 


### PR DESCRIPTION
Closes #1604 

- Adds `Plug.ErrorHandler` to the plug lesson
- Be consistent with use of `child_spec`
  - It was used in some places and not in others with no explanation. Made it consistent for the implicit use, but this can be changed if needed, I would just recommend we change it throughout the lesson if we go the explicit route.
- Update the `/upload` route to be a GET request so it's easier to test in browser and you don't need to setup a form or use another app to see that verify is working

cc @SophieDeBenedetto 
