### PR TITLE
Add section on functions and pattern matching.

### DIFF
--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -113,6 +113,154 @@ iex> Greeter2.hello("Fred", "Jane")
 
 We've listed the function names in comments above. The first implementation takes no arguments, so it is known as `hello/0`; the second takes one argument so it is known as `hello/1`, and so on. Unlike function overloads in some other languages, these are thought of as _different_ functions from each other. (Pattern matching, described just a moment ago, applies only when multiple definitions are provided for function definitions with the _same_ number of arguments.)
 
+### Functions and Pattern Matching
+
+Behind the scenes, functions are pattern-matching the arguments that they're called with.
+
+Say we needed a function to accept a map but we're only interested in using a particular key. We can pattern-match the argument on the presence of that key like this:
+
+```elixir
+defmodule Greeter1 do
+  def hello(%{name: person_name}) do
+    IO.puts "Hello, " <> person_name
+  end
+end
+```
+
+Now let's say we have a map describing a person named Fred:
+```elixir
+iex> fred = %{
+...> name: "Fred",
+...> age: "95",
+...> favorite_color: "Taupe"  
+...> }
+```
+
+These are the results we'll get when we call `Greeter1.hello/1  ` with the `fred` map:
+
+```elixir
+# call with entire map
+...> Greeter1.hello(fred)
+"Hello, Fred"
+```
+
+What happens when we call the function with a map that _doesn't_ contain the `:name` key?
+
+```elixir
+# call without the key we need returns an error
+...> Greeter1.hello(%{age: "95", favorite_color: "Taupe"})
+** (FunctionClauseError) no function clause matching in Greeter3.hello/1    
+
+    The following arguments were given to Greeter3.hello/1:
+
+        # 1
+        %{age: "95"}
+
+    iex:12: Greeter3.hello/1
+
+```
+
+The reason for this behavior is that Elixir pattern-matches the arguments that a function is called with against the arity the function is defined with.
+
+Let's think about how the data looks when it arrives to `Greeter1.hello/1`:
+
+```Elixir
+# incoming map
+iex> fred = %{
+...> name: "Fred",
+...> age: "95",
+...> favorite_color: "Taupe"  
+...> }
+```
+`Greeter1.hello/1` expects an argument like this:
+```elixir
+%{name: person_name}
+```
+In `Greeter1.hello/1`, the map we pass (`fred`) is evaluated against our argument (`%{name: person_name}`):
+
+```elixir
+%{name: person_name} = %{name: "Fred", age: "95", favorite_color: "Taupe"}
+```
+
+It finds that there is a key that corresponds to `name` in the incoming map. We have a match! And as a result of this successful match, the value of the `:name` key in the map on the right (i.e. the `fred` map) is bound to the variable on the left (`person_name`).
+
+Now, what if we still wanted to assign Fred's name to `person_name` but we ALSO want to retain awareness of the entire person map? Let's say we want to `IO.inspect(fred)` after we greet him. At this point, because we only pattern-matched the `:name` key of our map, thus only binding the value of that key to a variable, the function doesn't have knowledge of the rest of Fred.
+
+In order to retain it, we need to assign that entire map to its own variable for us to be able to use it.
+
+Let's start a new function:
+```elixir
+defmodule Greeter2 do
+  def hello(%{name: person_name} = person) do
+    IO.puts "Hello, " <> person_name
+    IO.inspect person
+  end
+end
+```
+
+Remember that Elixir will pattern match the argument as it comes in. Therefore in this case, each side will pattern match against the incoming argument and bind to whatever it matches with. Let's take the right side first:
+
+```elixir
+person = %{name: "Fred", age: "95", favorite_color: "Taupe"}
+```
+
+Now, `person` has been evaluated and bound to the entire fred-map. We move on to the next pattern-match:
+```elixir
+%{name: person_name} = %{name: "Fred", age: "95", favorite_color: "Taupe"}
+```
+
+Now this is the same as our original `Greeter1` function where we pattern matched the map and only retained Fred's name. What we've achieved is two variables we can use instead of one:
+1. `person`, referring to `%{name: "Fred", age: "95", favorite_color: "Taupe"}`
+2. `person_name`, referring to `"Fred"`
+
+So now when we call `Greeter2.hello/1`, we can use all of Fred's information:
+```elixir
+# call with entire person
+...> Greeter2.hello(fred)
+"Hello, Fred"
+%{age: "95", favorite_color: "Taupe", name: "Fred"}
+# call with only the name key
+...> Greeter4.hello(%{name: "Fred"})
+"Hello, Fred"
+%{name: "Fred"}
+# call without the name key
+...> Greeter4.hello(%{age: "95", favorite_color: "Taupe"})
+** (FunctionClauseError) no function clause matching in Greeter2.hello/1    
+
+    The following arguments were given to Greeter2.hello/1:
+
+        # 1
+        %{age: "95", favorite_color: "Taupe"}
+
+    iex:15: Greeter2.hello/1
+```
+
+So we've seen that Elixir pattern-matches at multiple depths because each argument matches against the incoming data independently, leaving us with the variables to call them by inside our function.
+
+If we switch the order of `%{name: person_name}` and `person` in the list, we will get the same result because each are matching to fred on their own.
+
+We swap the variable and the map:
+```elixir
+defmodule Greeter3 do
+  def hello(person = %{name: person_name}) do
+    IO.puts "Hello, " <> person_name
+    IO.inspect person
+  end
+end
+```
+
+And call it with the same data we used in `Greeter2.hello/1`:
+```elixir
+# call with same old Fred
+...> Greeter3.hello(fred)
+"Hello, Fred"
+%{age: "95", favorite_color: "Taupe", name: "Fred"}
+```
+
+Remember that even though it looks like `%{name: person_name} = person}` is pattern-matching the `%{name: person_name}` against the `person` variable, they're actually _each_ pattern-matching to the passed-in argument.
+
+**Summary:** Functions pattern-match the data passed in to each of its arguments independently. We can use this to bind values to separate variables within the function.
+
 ### Private Functions
 
 When we don't want other modules accessing a specific function we can make the function private.  Private functions can only be called from within their own Module.  We define them in Elixir with `defp`:

--- a/en/lessons/basics/functions.md
+++ b/en/lessons/basics/functions.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.2.0
 title: Functions
 ---
 


### PR DESCRIPTION
This is a PR to add clarity on pattern matching within function parameters. 

I'd like particular feedback on the following:
One thing I've seen in a few blog posts is that there's an order to the way incoming parameters are matched against the function argument.

For example, if we have 
```elixir
def hello(%{name: name} = person)
```
an incoming map would first match against person, then move on to matching `person` against `%{name: name}`. From what I could tell, the two parts of the argument are independently matching against incoming parameters; the order doesn't matter because they aren't pattern matching against each other. I would love to hear any clarifying thoughts on this part and if I've misunderstood.

For reference, an excerpt from one of the blogs:
> Elixir is pattern matching params first (the passed in map is the right-hand side, params becomes the left), then pattern matches user_id, as the left-hand side, against params which is now the right-hand side, like so.
-- [@turnandface - Pattern Matching in Elixir](https://medium.com/@turnandface/pattern-matching-in-elixir-743e71ceac92)
 