### PR TITLE
rake assets:precompile should use 'system' not 'puts'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 namespace :assets do
   task :precompile do
-    puts `bundle exec jekyll build`
+    system 'bundle exec jekyll build'
   end
 end


### PR DESCRIPTION
This _should_ resolve the "Jekyll is currently rendering the site" indefinitely errors on Heroku. 