### PR TITLE
Don't suggest that the concept of an interface will be familiar to Ruby developers

### DIFF
--- a/en/lessons/advanced/typespec.md
+++ b/en/lessons/advanced/typespec.md
@@ -23,7 +23,7 @@ That means all information about a type will be ignored by the compiler, but cou
 
 ## Specification
 
-If you have experience with Java or Ruby you could think about specification as an `interface`.
+If you have experience with Java you could think about specification as an `interface`.
 Specification defines what should be the type of a function's parameters and of it's return value.
 
 To define input and output types we use the `@spec` directive placed right before the function definition and taking as a `params` the name of the function, a list of parameter types, and after `::` the type of the return value.

--- a/en/lessons/advanced/typespec.md
+++ b/en/lessons/advanced/typespec.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: Specifications and types
 ---
 


### PR DESCRIPTION
The "Specifications and types" page compares Elixir's "specifications" to the concept of an "interface", suggesting that this might be a helpful analogy if you're familiar with Java or Ruby.

Ruby doesn't have a concept of interfaces in the language, so this seems like a bit of an odd thing to say. (Although the generic, abstract concept of an "interface", as in a "contract", is likely to be familiar to many programmers.)

This removes this reference to Ruby, just referring to Java instead.