### PR TITLE
Explain better the use of exceptions with a `:plug_status` field in the the "Plug" guide

### DIFF
--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -1,5 +1,5 @@
 ---
-version: 2.1.2
+version: 2.2.0
 title: Plug
 ---
 

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -430,7 +430,7 @@ defmodule Example.Router do
   get("/upload", do: send_resp(conn, 201, "Uploaded\n"))
   match(_, do: send_resp(conn, 404, "Oops!\n"))
 
-  def handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
+  defp handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
     IO.puts "Kind:"
     IO.inspect kind
     IO.puts "Reason:"

--- a/en/lessons/specifics/plug.md
+++ b/en/lessons/specifics/plug.md
@@ -1,5 +1,5 @@
 ---
-version: 2.1.1
+version: 2.1.2
 title: Plug
 ---
 
@@ -219,7 +219,7 @@ defmodule Example.Plug.VerifyRequest do
     Error raised when a required field is missing.
     """
 
-    defexception message: "", plug_status: 400
+    defexception message: ""
   end
 
   def init(options), do: options
@@ -242,8 +242,7 @@ defmodule Example.Plug.VerifyRequest do
 end
 ```
 
-The first thing to note is we have defined a new exception `IncompleteRequestError` and that one of its options is `:plug_status`.
-When available this option is used by Plug to set the HTTP status code in the event of an exception.
+The first thing to note is we have defined a new exception `IncompleteRequestError` which we'll raise in the event of an invalid request.
 
 The second portion of our Plug is the `call/2` function.
 This is where we decide whether or not to apply our verification logic.
@@ -297,11 +296,11 @@ This in turn passes the given options to the `VerifyRequest.call(conn, opts)` fu
 
 Let's take a look at this plug in action! Go ahead and crash your local server (rember, that's done by pressing `ctrl + c` twice).
 Then restart the server (`mix run --no-halt`).
-Now go to <http://127.0.0.1:8080/upload> in your browser and you'll see that the page simply isn't working.
-We're not even getting our 'Oops!' message.
-Now let's add our required params by going to <http://127.0.0.1:8080/upload?content=thing1&mimetype=thing2>.
-Now we should see our 'Uploaded' message.
-It's not great that when we throw an error we don't get _any_ page, but we'll deal with how to handle errors with plugs later.
+Now go to <http://127.0.0.1:8080/upload> in your browser and you'll see that the page simply isn't working. You'll just see a default error page provided by your browser.
+
+Now let's add our required params by going to <http://127.0.0.1:8080/upload?content=thing1&mimetype=thing2>. Now we should see our 'Uploaded' message.
+
+It's not great that when we raise an error, we don't get _any_ page. We'll look at how to handle errors with plugs later.
 
 ## Making The HTTP Port Configurable
 
@@ -403,7 +402,8 @@ $ mix test test/example/router_test.exs
 
 ## Plug.ErrorHandler
 
-We noticed earlier that when we go to <http://127.0.0.1:8080/upload> we don't even see an error page.
+We noticed earlier that when we went to <http://127.0.0.1:8080/upload> without the expected parameters, we didn't get a friendly error page or a sensible HTTP status - just our browser's default error page with a `500 Internal Server Error`.
+
 Let's fix that now by adding in [`Plug.ErrorHandler`](https://hexdocs.pm/plug/Plug.ErrorHandler.html).
 
 First, open up `lib/example/router.ex` and then write the following to that file.
@@ -442,23 +442,23 @@ defmodule Example.Router do
 end
 ```
 
-You'll notice at the top we are now adding `use Plug.ErrorHandler`.
-This plug now catches any error and then looks for a function `handle_errors/2` to call.
-`handle_errors` just needs to accept the `conn` as the first argument and then a map with three items (`:kind`, `:reason`, and `:stack`) as the second.
-You can see we've defined a very some `handle_errors` to see what's going on.
-Let's stop and restart our app again to see how this works!
+You'll notice that at the top, we are now adding `use Plug.ErrorHandler`.
 
-Now, when you navigate to <http://127.0.0.1:8080/upload>, we see an error message 'Something went wrong'.
+This plug catches any error, and then looks for a function `handle_errors/2` to call in order to handle it.
+
+`handle_errors/2` just needs to accept the `conn` as the first argument and then a map with three items (`:kind`, `:reason`, and `:stack`) as the second.
+
+You can see we've defined a very simple `handle_errors/2` function to see what's going on. Let's stop and restart our app again to see how this works!
+
+Now, when you navigate to <http://127.0.0.1:8080/upload>, you'll see a friendly error message.
+
 If you look in your terminal, you'll see something like the following:
 
 ```shell
 Kind:
 :error
 Reason:
-%Example.Plug.VerifyRequest.IncompleteRequestError{
-  message: "",
-  plug_status: 400
-}
+%Example.Plug.VerifyRequest.IncompleteRequestError{message: ""}
 Stack
 [
   {Example.Plug.VerifyRequest, :verify_request!, 2,
@@ -488,7 +488,17 @@ Stack
 ]
 ```
 
-This plug makes it really easy to catch the useful information needed for developers to fix issues while being able to also give our end user a nice page so it doesn't look like our app totally blew up!
+At the moment, we're still sending a `500 Internal Server Error` back. We can customise the status code by adding a `:plug_status` field to our exception. Open up `lib/example/plug/verify_request.ex` and add the following:
+
+```elixir
+defmodule IncompleteRequestError do
+  defexception message: "", plug_status: 400
+end
+```
+
+Restart your server and refresh, and now you'll get back a `400 Bad Request`.
+
+This plug makes it really easy to catch the useful information needed for developers to fix issues, while being able to also give our end user a nice page so it doesn't look like our app totally blew up!
 
 ## Available Plugs
 


### PR DESCRIPTION
At the moment, the "Plug" page is a bit confusing in that it tells you to add a `:plug_status` field to your custom exception when it won't work until much later in the guide.

This adds the `:plug_status` field much later, after we've set up the `Plug.ErrorHandler` plug, and explains how it works a bit better.