### PR TITLE
Retrieve all author's metadata from contributors.yml

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,11 +7,7 @@ layout: default
 <section id="section-page">
   <header class="main">
     <h1 class="post-title">{{ page.title }}</h1>
-    {% if contributor.homepage %}
-      <p>{{ page.date | date_to_string }} · by <a href="{{ contributor.homepage }}">{{page.author}}</a></p>
-    {% else %}
-      <p>{{ page.date | date_to_string }} · by <a href="https://github.com/{{ contributor.github }}">{{page.author}}</a></p>
-    {% endif %}
+    <p>{% assign author_url = contributor.homepage | default: 'https://github.com/' | append: contributor.github %} {{ page.date | date_to_string }} · by <a href="{{ author_url }}">{{page.author}}</a></p>
   </header>
   <div class="content">
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,10 +1,17 @@
 ---
 layout: default
 ---
+
+{% include function-getContributor type="name" search=page.author %}
+
 <section id="section-page">
   <header class="main">
     <h1 class="post-title">{{ page.title }}</h1>
-    <p>{{ page.date | date_to_string }} · by <a href="{{page.author_link}}">{{page.author}}</a></p>
+    {% if contributor.homepage %}
+      <p>{{ page.date | date_to_string }} · by <a href="{{ contributor.homepage }}">{{page.author}}</a></p>
+    {% else %}
+      <p>{{ page.date | date_to_string }} · by <a href="https://github.com/{{ contributor.github }}">{{page.author}}</a></p>
+    {% endif %}
   </header>
   <div class="content">
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,11 @@ layout: default
 <section id="section-page">
   <header class="main">
     <h1 class="post-title">{{ page.title }}</h1>
-    <p>{% assign author_url = contributor.homepage | default: 'https://github.com/' | append: contributor.github %} {{ page.date | date_to_string }} · by <a href="{{ author_url }}">{{page.author}}</a></p>
+    {% if contributor.homepage %}
+      <p>{{ page.date | date_to_string }} · by <a href="{{ contributor.homepage }}">{{page.author}}</a></p>
+    {% else %}
+      <p>{{ page.date | date_to_string }} · by <a href="https://github.com/{{ contributor.github }}">{{page.author}}</a></p>
+    {% endif %}
   </header>
   <div class="content">
     {{ content }}


### PR DESCRIPTION
Retrieve the information of the author of a blog post from `contributors.yml`
if the author's website is unknow we fallback on their github page.