### PR TITLE
Whitespace/tiny fixes

### DIFF
--- a/en/lessons/basics/date-time.md
+++ b/en/lessons/basics/date-time.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Date and Time
 ---
 
@@ -63,7 +63,7 @@ true
 ```
 
 `day_of_week/1` calculates which day of week would be the given date.
-In this case it's saturday.
+In this case it's Saturday.
 `leap_year?/1` checks whether this is a leap year.
 Other functions can be found in [doc](https://hexdocs.pm/elixir/Date.html).
 

--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: Custom Mix Tasks
 ---
 
@@ -31,7 +31,7 @@ What if we could create something similar for our project? Well the great news i
 
 ## Setup
 
-Let's set up a very basic Mix application.
+Let's set up a basic Mix application.
 
 ```shell
 $ mix new hello

--- a/en/lessons/basics/sigils.md
+++ b/en/lessons/basics/sigils.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Sigils
 ---
 
@@ -155,7 +155,7 @@ iex> ~W/i love #{'e'}lixir school/
 A [NaiveDateTime](https://hexdocs.pm/elixir/NaiveDateTime.html) can be useful for quickly creating a struct to represent a `DateTime` **without** a timezone.
 
 For the most part, we should avoid creating a `NaiveDateTime` struct directly.
-However, it is very useful for pattern matching.
+However, it is useful for pattern matching.
 For example:
 
 ```elixir

--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -1,5 +1,5 @@
 ---
-version: 2.1.0
+version: 2.1.1
 title: Basics
 ---
 
@@ -9,7 +9,7 @@ Ecto is an official Elixir project providing a database wrapper and integrated q
 
 ### Adapters
 
-Ecto supports different databases through the use of adapters.  A few examples of adapters are:
+Ecto supports different databases through the use of adapters. A few examples of adapters are:
 
 * PostgreSQL
 * MySQL

--- a/en/lessons/ecto/changesets.md
+++ b/en/lessons/ecto/changesets.md
@@ -1,10 +1,9 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Changesets
 ---
 
-In order to insert, update or delete data from the database, `Ecto.Repo.insert/2`, `update/2` and `delete/2` require a changeset as their first parameter.
-But what exactly are changesets?
+In order to insert, update or delete data from the database, `Ecto.Repo.insert/2`, `update/2` and `delete/2` require a changeset as their first parameter. But what are changesets?
 
 A familiar task for almost every developer is checking input data for potential errors — we want to make sure that data is in the right state, before we attempt to use it for our purposes.
 
@@ -14,7 +13,7 @@ In this lesson we're going to explore this functionality and learn how to verify
 {% include toc.html %}
 
 ## Creating your first changeset
- 
+
 Let's look at an empty `%Changeset{}` struct:
 
 ```elixir
@@ -27,7 +26,7 @@ As you can see, it has some potentially useful fields, but they are all empty.
 For a changeset to be truly useful, when we create it, we need to provide a blueprint of what the data is like.
 What better blueprint for our data than the schemas we've created that define our fields and types?
 
-Let's see a common `User` schema:  
+Let's see a common `User` schema:
 
 ```elixir
 defmodule User do

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Querying
 ---
 
@@ -129,7 +129,7 @@ You can use query expressions when you _don't_ need an `in` statement (`m in Mov
 We use the `Ecto.Query.select/3` function to specify the select statement portion of our query. If we want to select only certain fields, we can specify those fields as a list of atoms or by referencing the struct's keys. Let's take a look at the first approach:
 
 ```elixir
-iex> query = from(Movie, select: [:title])                                            
+iex> query = from(Movie, select: [:title])
 #Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
@@ -154,9 +154,9 @@ This approach returns a struct with only the specified field, `title`, populated
 The second approach behaves a little differently. This time, we *do* need to use an `in` expression. This is because we need to create a reference to our data structure in order to specify the `title` key of the movie struct:
 
 ```elixir
-iex(15)> query = from(m in Movie, select: m.title)   
+iex(15)> query = from(m in Movie, select: m.title)
 #Ecto.Query<from m in Example.Movie, select: m.title>
-iex(16)> Repo.all(query)                             
+iex(16)> Repo.all(query)
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
 ["Ready Player One"]
@@ -169,7 +169,7 @@ Notice that this approach to using `select` returns a list containing the select
 We can use `where` expressions to include "where" clauses in our queries. Multiple `where` expressions are combined into `WHERE AND` SQL statements.
 
 ```elixir
-iex> query = from(m in Movie, where: m.title == "Ready Player One")                   
+iex> query = from(m in Movie, where: m.title == "Ready Player One")
 #Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
@@ -205,7 +205,7 @@ In order to use interpolated values or Elixir expressions in our where clauses, 
 ```elixir
 iex> title = "Ready Player One"
 "Ready Player One"
-iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)            
+iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)
 #Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
@@ -306,7 +306,7 @@ We can cut down on our database queries with the following:
 
 ```elixir
 iex> query = from(m in Movie, join: a in assoc(m, :actors), preload: [actors: a])
-iex> Repo.all(query)  
+iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
@@ -440,4 +440,4 @@ from c in Character,
   select: {m.title, c.name}
 ```
 
-The Ecto Query DSL is a powerful tool that provides us with everything we need to make even complex database queries. With this introduction provides you with the basic building blocks to start querying.   
+The Ecto Query DSL is a powerful tool that provides us with everything we need to make even complex database queries. With this introduction provides you with the basic building blocks to start querying.

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Guardian (Basics)
 ---
 
@@ -64,8 +64,7 @@ We'll cover that later.
 
 ## Setup
 
-There are many options for setting up Guardian.
-We'll cover them at some point but let's start with a very simple setup.
+There are many options for setting up Guardian. We'll cover them at some point but let's start with a simple setup.
 
 ### Minimal Setup
 

--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Poolboy
 ---
 
@@ -184,4 +184,4 @@ In our example, we've increased the default timeout to one minute in order to de
 In case of this app, you can observe the error if you change the value of `@timeout` to less than 1000.
 
 Even though we're attempting to create multiple processes *(total of twenty in the example above)* `:poolboy.transaction/3` function will limit the maximum number of created processes to five *(plus two overflow workers if needed)* as we have defined in our configuration.
-All requests will be handled using the pool of workers rather than creating a new process for each and every request.
+All requests will be handled using the pool of workers rather than creating a new process for every request.


### PR DESCRIPTION
Once again as in #712 , I'm going through project texts via `proselint`.

Mostly, whitespace (double-space or trailing space) fixes, typos (i.e. capital letter) and small readability changes (i.e. merging two related paragraphs, removing `very`, etc).

I'm actually not sure whether should I update versions or not, as these changes don't affect the actual texts.


