### PR TITLE
Update and sync CONTRIBUTING and README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ Please ensure your pull request adheres to the following guidelines:
 
 * New lessons or improvements to existing lessons are welcome.
 * Please check your spelling and grammar.
-* Open an issue to handle translations if adding a new lesson or modifying an existing one. An example can be found [here](https://github.com/elixirschool/elixirschool/issues/529)
+* Open an issue to handle translations if adding a new lesson or modifying an existing one. You can find an example [here](https://github.com/elixirschool/elixirschool/issues/529)
 * Please adhere to our [style guide](https://github.com/elixirschool/elixirschool/wiki/Lesson-Styleguide)
 
 ## A Note on Lesson Versions
 
-All lessons should include the follow front matter:
+All lessons should include the following front matter:
 
 ```markdown
 ---
@@ -25,7 +25,7 @@ Change the `version` attribute according to the following rules:
 * MINOR — Added or removed some content, few sentences, etc.
 * PATCH — Spelling, typos. Probably not translated stuff.
 
-Fun fact! The version changes are important because we use that to programmatically determine and inform translators of new content that requires translation.
+Fun fact! The version changes are necessary because we use that to programmatically determine and inform translators of new content that requires translation.
 
 ## Adding a New Lesson
 To add a new lesson, create the file under the appropriate directory in `en/lessons` (or `<language_code>/lessons`) if you are not writing your new lesson in English).
@@ -36,8 +36,40 @@ If you've added a new section (i.e. a new directory under `/lessons`), add the s
 
 Thank you for your contributions!
 
+
+## Adding a new Language
+
+1. Create a folder using the ISO language code (e.g. ja, zh-hans, es, et al) with lesson subfolders.
+Not sure which language code to use?
+Check [here](https://www.loc.gov/standards/iso639-2/php/English_list.php) for the official list.
+
+  ```shell
+  $ cd elixirschool
+  $ mkdir -p ja/lessons/{basics,advanced,specifics,libraries}
+  $ touch ja/lessons/{basics,advanced,specifics,libraries}/.gitkeep
+  ```
+
+1. Add your language code to `interlang` in `_data/locales/en.yml`:
+
+  ```yaml
+  interlang:
+   ja: Japanese
+  ```
+
+1. Create a locale file for your new language using `_data/locales/en.yml` as a guide:
+
+  ```shell
+  $ touch _data/locales/ja.yml
+  ```
+
+1. If the new language is RTL (right-to-left) it should be added to the `rtl_languages` list in `config.yml`:
+
+  ```yaml
+  script_direction: rtl
+  ```
+
 ## Gotcha
 
 Look out for Liquid templating weirdness!
 
-If you have a code snippet that includes the following syntax: `{%{message: "error message"}, :error}`, i.e. if you have a tuple where the first element is a map, WATCH OUT! That set of characters, `{%` is actually the start of a liquid tag! Instead, wrap your backticked code block in `{% raw % }` `{% endraw %}`
+If you have a code snippet that includes the following syntax: `{%{message: "error message"}, :error}`, i.e. if you have a tuple where the first element is a map, WATCH OUT! That set of characters, `{%` is the start of a liquid tag! Instead, wrap your backticked code block in `{% raw % }` `{% endraw %}`

--- a/README.md
+++ b/README.md
@@ -2,69 +2,35 @@
 
 > Elixir School is the premier destination for people looking to learn and master the Elixir programming language.
 
-Lessons can now be viewed at [ElixirSchool.com](https://elixirschool.com).
+You can access lessons at [ElixirSchool.com](https://elixirschool.com).
 
-_Feedback and participation is strongly encouraged! Please see [Contributing](CONTRIBUTING.md) for more details on how to get involved._
+_Feedback and participation are strongly encouraged! Please see [Contributing](CONTRIBUTING.md) for more details on how to get involved._
 
-### Running
+### Running locally
 
 [ElixirSchool.com](https://elixirschool.com) is generated using [Jekyll](https://github.com/jekyll/jekyll).
-To run locally you need both Ruby and Bundler installed.
+To run locally, you need both Ruby and Bundler installed.
 
 1. Install dependencies:
 
-	```shell
-	$ bundle install
-	```
+  ```shell
+  $ bundle install
+  ```
 
 1. Run Jekyll:
 
-	```shell
-	$ bundle exec jekyll s
-	```
-
-1. Read it at [http://localhost:4000](http://localhost:4000)
-
-### Translating
-
-In addition to the steps above there are a few addition steps required for translation.
-
-#### New Language
-
-1. Create a folder using the ISO language code (e.g. ja, zh-hans, es, et al) with lesson subfolders.
-Not sure which language code to use?
-Check [here](https://www.loc.gov/standards/iso639-2/php/English_list.php) for the official list.
-
   ```shell
-  $ cd elixirschool
-  $ mkdir -p ja/lessons/{basics,advanced,specifics,libraries}
-  $ touch ja/lessons/{basics,advanced,specifics,libraries}/.gitkeep
+  $ bundle exec jekyll s
   ```
 
-1. Add your language code to `interlang` in `_data/locales/en.yml`:
+1. Access it at [http://localhost:4000](http://localhost:4000)
 
-  ```yaml
-  interlang:
-   ja: Japanese
-  ```
+### Translating a Lesson
 
-1. Create a locale file for your new language using `_data/locales/en.yml` as a guide:
-
-  ```shell
-  $ touch _data/locales/ja.yml
-  ```
-
-1. If the new language is RTL (right-to-left) it should be added to the `rtl_languages` list in `config.yml`:
-
-  ```yaml
-  script_direction: rtl
-  ```
-
-#### Translated Lesson
-
-1. Translated lessons must include the page metadata.
+1. Each of the languages has a folder in root this repo. To start translating you need to copy a file from the English language to the corresponding folder in your language and start translating.
+1. Translated lessons must include page metadata.
    * `title` should be a translation of the original lesson's `title`.
-   * `version` should be set to the original English `version`
+   * `version` should be set to the original English `version`.
 
    For example `/ja/lessons/basics/basics.md`:
 
@@ -74,9 +40,6 @@ Check [here](https://www.loc.gov/standards/iso639-2/php/English_list.php) for th
   version: 1.0.0
   ---
   ```
+1. Send a PR with the new translated lesson and join [https://elixirschool.com/contributors/](contributors).
 
-## New Lessons
 
-Contributing a new lesson?
-Wonderful!
-In addition to creating the new lesson be sure to add it to `_data/contents.yml`.


### PR DESCRIPTION
Seems like after updating CONTRIBUTING guide README wasn't updated. Let's fix that.

Also, readability/spelling/grammar fixes. It's the root page of the repo, after all. 😄 

Moving some parts from README to contributing, removing duplicates.