### PR TITLE
Fix path and module name in LiveView post

### DIFF
--- a/_posts/2018-03-18-phoenix-live-view.md
+++ b/_posts/2018-03-18-phoenix-live-view.md
@@ -132,7 +132,7 @@ config :demo, MyApp.Endpoint,
   live_reload: [
     patterns: [
       ...,
-      ~r{lib/my_app/live/.*(ex)$}
+      ~r{lib/my_app_web/live/.*(ex)$}
     ]
   ]
 ```

--- a/_posts/2018-03-18-phoenix-live-view.md
+++ b/_posts/2018-03-18-phoenix-live-view.md
@@ -149,7 +149,7 @@ defmodule MyApp.PageController do
   alias Phoenix.LiveView
 
   def index(conn, _) do
-    LiveView.Controller.live_render(conn, MyApp.GithubDeployView, session: %{})
+    LiveView.Controller.live_render(conn, MyAppWeb.GithubDeployView, session: %{})
   end
 end
 ```


### PR DESCRIPTION
* fix live reloading path in example
* fix module name for GithubDeployView 