### PR TITLE
fix: #main div stretching too much

### DIFF
--- a/_assets/stylesheets/layout/_main.scss
+++ b/_assets/stylesheets/layout/_main.scss
@@ -3,7 +3,7 @@
 	#main {
 		@include vendor('flex-grow', '1');
 		@include vendor('flex-shrink', '1');
-		width: 100%;
+		width: calc(100vw - #{_size(sidebar-width)});
 
 		> .inner {
 			@include padding(0, 6em);
@@ -21,6 +21,8 @@
 		}
 
 		@include breakpoint(xlarge) {
+			width: calc(100vw - #{_size(sidebar-width-alt)});
+
 			> .inner {
 				@include padding(0, 5em);
 


### PR DESCRIPTION
#main div stretches too much when very long strings without breaks are present, making the sidebar disappear out of view

Fixes #1751