### PR TITLE
fix unresponsive embeds

### DIFF
--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -223,3 +223,18 @@ pre {
     }
   }
 }
+
+.responsive-embed {
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+}

--- a/_posts/2018-03-18-phoenix-live-view.md
+++ b/_posts/2018-03-18-phoenix-live-view.md
@@ -28,7 +28,10 @@ Let's get LiveView up and running to support a feature that pushes out live upda
 
 Here's the functionality we're building:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" frameborder="0" allowfullscreen></iframe><br />
+<div class="responsive-embed">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" frameborder="0" allowfullscreen></iframe>
+</div>
+<br />
 
 ## Getting Started
 


### PR DESCRIPTION
adding a css class to make iframes responsive and respect the viewport's witdth
this avoids the horizontal scrollbar on mobile

before:
<img width="355" alt="Screenshot 2019-03-24 at 11 08 15" src="https://user-images.githubusercontent.com/16062635/54878632-37e5aa00-4e27-11e9-8774-f05b16bfa298.png">

after:
<img width="399" alt="Screenshot 2019-03-24 at 11 09 49" src="https://user-images.githubusercontent.com/16062635/54878636-3c11c780-4e27-11e9-8dbb-b6e536077f1d.png">
