### PR TITLE
`phx.gen.secret` generates a secret, not `phx.secret`

### DIFF
--- a/_posts/2018-03-18-phoenix-live-view.md
+++ b/_posts/2018-03-18-phoenix-live-view.md
@@ -54,7 +54,7 @@ config :my_app, MyApp.Endpoint,
     signing_salt: "YOUR_SECRET"
   ]
 ```
-*Note: You can generate a secret by running `mix phx.secret` from the command line.*
+*Note: You can generate a secret by running `mix phx.gen.secret` from the command line.*
 
 3. Update your configuration to enable writing LiveView templates with the  `.leex` extension.
 


### PR DESCRIPTION
Looks like the correct mix tasks for this is `phx.gen.secret`, not `phx.secret`. See https://hexdocs.pm/phoenix/phoenix_mix_tasks.html