### PR TITLE
Fix icon class for last commit on Report page

### DIFF
--- a/_includes/report.html
+++ b/_includes/report.html
@@ -36,7 +36,7 @@
               {% if lesson[1]['last_commit'] == '' %}
               {% else %}
               <a class="icon" href="{{ lesson[1]['last_commit'] }}">
-                  <i class="fab fa-github-square"></i>
+                  <i class="fa fa-github-square"></i>
                   <span class="label">{{ headers['last_commit'] }}</span>
               </a>
               {% endif %}


### PR DESCRIPTION

| Before   | After    |
| -------- | -------- |
|![image](https://user-images.githubusercontent.com/4408379/55836235-a9f80780-5b26-11e9-9227-91bf6ad10237.png)|![image](https://user-images.githubusercontent.com/4408379/55836466-3b677980-5b27-11e9-9148-34945bbb2c66.png)|

Typo :)

