### PR TITLE
Remove Google+ share icon

### DIFF
--- a/_includes/share-icons.html
+++ b/_includes/share-icons.html
@@ -6,7 +6,6 @@
   {% endif %}
   <li><a target="_blank" rel="noopener" title="LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ page.url }}&title={{ title }}&summary=description&source={{ site.url }}" class="icon fa-linkedin"><span class="label">Linkedin</span></a></li>
   <li><a target="_blank" rel="noopener" title="Twitter" href="https://twitter.com/intent/tweet?url={{ site.url }}{{ page.url }}&via=elixirschool&text=ElixirSchool: {{ title }}&hashtags=learnelixir%2Celixirlang&" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
-  <li><a target="_blank" rel="noopener" title="Google+" href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}" class="icon fa-google-plus"><span class="label">Google+</span></a></li>
   <li><a target="_blank" rel="noopener" title="Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}" class="icon fa-facebook"><span class="label">Facebook</span></a></li>
   <li><a target="_blank" rel="noopener" title="Pinterest" href="https://www.pinterest.com/pin/create/link/?url={{ site.url }}{{ page.url }}&media={{ site.url }}{% asset og_image.jpg @path %}&description=ElixirSchool: {{ title }}" class="icon fa-pinterest"><span class="label">Pinterest</span></a></li>
   <li><a target="_blank" rel="noopener" title="VK" href="https://vk.com/share.php?url={{ site.url }}{{ page.url }}&title=ElixirSchool: {{ title }}&description=Check out '{{ title }}' on ElixirSchool" class="icon fa-vk"><span class="label">VK</span></a></li>


### PR DESCRIPTION
As Google+ doesn't exist anymore, the link in social sharing list should be removed.