### PR TITLE
Multiple blog authors

### DIFF
--- a/_includes/contributor-profile.html
+++ b/_includes/contributor-profile.html
@@ -11,7 +11,7 @@
     <p class="content">{{ include.contributor.intro }}</p>
     <ul class="icons">
       {% if include.contributor.homepage %}
-      <li><a href="{{ include.contributor.homepage }}" class="icon"><i class="fa fa-globe"></i> <span class="label">Homepage</span></a></li>
+      <li><a href="{{ include.contributor.homepage }}" class="icon fa-globe"><span class="label">Homepage</span></a></li>
       {% endif %}
       {% if include.contributor.twitter %}
       <li><a href="https://twitter.com/{{ include.contributor.twitter }}" class="icon fa-twitter"><span class="label">Twitter</span></a></li>

--- a/_includes/function-displayAuthor
+++ b/_includes/function-displayAuthor
@@ -1,0 +1,7 @@
+{%- if include.contributor -%}
+  {%- if include.contributor.homepage -%}
+    <a href="{{ include.contributor.homepage }}">{{include.contributor.name}}</a>
+  {%- else -%}
+    <a href="https://github.com/{{ include.contributor.github }}">{{include.contributor.name}}</a>
+  {%- endif -%}
+{%- endif -%}

--- a/_includes/function-displayAuthor
+++ b/_includes/function-displayAuthor
@@ -2,6 +2,6 @@
   {%- if include.contributor.homepage -%}
     <a href="{{ include.contributor.homepage }}">{{include.contributor.name}}</a>
   {%- else -%}
-    <a href="https://github.com/{{ include.contributor.github }}">{{include.contributor.name}}</a>
+    <a href="https://github.com/{{ include.contributor.github }}" target="_blank" rel="nofollow noopener">{{include.contributor.name}}</a>
   {%- endif -%}
 {%- endif -%}

--- a/_includes/function-displayAuthor
+++ b/_includes/function-displayAuthor
@@ -1,6 +1,6 @@
 {%- if include.contributor -%}
   {%- if include.contributor.homepage -%}
-    <a href="{{ include.contributor.homepage }}">{{include.contributor.name}}</a>
+    <a href="{{ include.contributor.homepage }}" target="_blank" rel="nofollow noopener">{{include.contributor.name}}</a>
   {%- else -%}
     <a href="https://github.com/{{ include.contributor.github }}" target="_blank" rel="nofollow noopener">{{include.contributor.name}}</a>
   {%- endif -%}

--- a/_includes/section-author.html
+++ b/_includes/section-author.html
@@ -1,6 +1,5 @@
-{% include function-getContributor type="name" search=page.author %}
 {% if contributor %}
-<section class="blog-author">
-  {% include contributor-profile.html contributor=contributor %}
-</section>
+  
+    {% include contributor-profile.html contributor=contributor %}
+  
 {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,21 +1,40 @@
 ---
 layout: default
 ---
-
-{% include function-getContributor type="name" search=page.author %}
+{%- if page.authors -%}
+  {%- capture links -%}
+    {%- for author in page.authors -%}
+      {% include function-getContributor type="name" search=author %}
+      {% include function-displayAuthor contributor=contributor %}\
+    {%- endfor -%}
+  {%- endcapture -%}
+  {% assign authors = links | split: "\" | array_to_sentence_string %}
+{%- else -%}
+  {%- capture authors -%}
+    {% include function-getContributor type="name" search=page.author %}
+    {% include function-displayAuthor contributor=contributor %}
+  {%- endcapture -%}
+{%- endif -%}
 
 <section id="section-page">
   <header class="main">
     <h1 class="post-title">{{ page.title }}</h1>
-    {% if contributor.homepage %}
-      <p>{{ page.date | date_to_string }} · by <a href="{{ contributor.homepage }}">{{page.author}}</a></p>
-    {% else %}
-      <p>{{ page.date | date_to_string }} · by <a href="https://github.com/{{ contributor.github }}">{{page.author}}</a></p>
-    {% endif %}
+    <p>{{ page.date | date_to_string }} · by {{ authors }}</p>
   </header>
   <div class="content">
     {{ content }}
   </div>
 </section>
 {% include section-prevnext.html %}
-{% include section-author.html %}
+<section> 
+  {%- if page.authors -%}
+    {%- for author in page.authors -%}
+      {% include function-getContributor type="name" search=author %}
+      {% include section-author.html %}
+      <hr>
+    {%- endfor -%}  
+  {%- else -%}
+    {% include function-getContributor type="name" search=page.author %}
+    {% include section-author.html %}
+  {%- endif -%}  
+</section>


### PR DESCRIPTION
- Multiple blog authors are now supported via `authors` block in post's 
front matter 
ex: `authors: ['burden', 'Sean Callan']`

- Article’s header now displays authors in order of appearance.
<img width="660" alt="Screen Shot 2019-04-30 at 2 29 47 AM" src="https://user-images.githubusercontent.com/73517/56955286-d1267100-6af5-11e9-9f35-1a9692fb65e2.png">

- Footer also displays authors in order of appearance.
<img width="596" alt="Screen Shot 2019-04-30 at 3 09 55 AM" src="https://user-images.githubusercontent.com/73517/56955296-d84d7f00-6af5-11e9-97f4-c30886337dae.png">
