### PR TITLE
Refactor code snippets for readability

### DIFF
--- a/zh-hant/lessons/specifics/plug.md
+++ b/zh-hant/lessons/specifics/plug.md
@@ -160,11 +160,16 @@ Hello World!
 defmodule Example.Router do
   use Plug.Router
 
-  plug(:match)
-  plug(:dispatch)
+  plug :match
+  plug :dispatch
 
-  get("/", do: send_resp(conn, 200, "Welcome"))
-  match(_, do: send_resp(conn, 404, "Oops!"))
+  get "/" do
+    send_resp(conn, 200, "Welcome")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Oops!")
+  end
 end
 ```
 
@@ -263,20 +268,22 @@ defmodule Example.Router do
 
   alias Example.Plug.VerifyRequest
 
-  plug(Plug.Parsers, parsers: [:urlencoded, :multipart])
+  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
+  plug VerifyRequest, fields: ["content", "mimetype"], paths: ["/upload"]
+  plug :match
+  plug :dispatch
 
-  plug(
-    VerifyRequest,
-    fields: ["content", "mimetype"],
-    paths: ["/upload"]
-  )
+  get "/" do
+    send_resp(conn, 200, "Welcome")
+  end
 
-  plug(:match)
-  plug(:dispatch)
+  get "/upload" do
+    send_resp(conn, 201, "Uploaded")
+  end
 
-  get("/", do: send_resp(conn, 200, "Welcome\n"))
-  get("/upload", do: send_resp(conn, 201, "Uploaded\n"))
-  match(_, do: send_resp(conn, 404, "Oops!\n"))
+  match _ do
+    send_resp(conn, 404, "Oops!")
+  end
 end
 ```
 
@@ -367,7 +374,8 @@ defmodule Example.RouterTest do
 
   test "returns welcome" do
     conn =
-      conn(:get, "/", "")
+      :get
+      |> conn("/", "")
       |> Router.call(@opts)
 
     assert conn.state == :sent
@@ -376,7 +384,8 @@ defmodule Example.RouterTest do
 
   test "returns uploaded" do
     conn =
-      conn(:get, "/upload?content=#{@content}&mimetype=#{@mimetype}")
+      :get
+      |> conn("/upload?content=#{@content}&mimetype=#{@mimetype}")
       |> Router.call(@opts)
 
     assert conn.state == :sent
@@ -385,7 +394,8 @@ defmodule Example.RouterTest do
 
   test "returns 404" do
     conn =
-      conn(:get, "/missing", "")
+      :get
+      |> conn("/missing", "")
       |> Router.call(@opts)
 
     assert conn.state == :sent
@@ -415,28 +425,27 @@ defmodule Example.Router do
 
   alias Example.Plug.VerifyRequest
 
-  plug(Plug.Parsers, parsers: [:urlencoded, :multipart])
+  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
+  plug VerifyRequest, fields: ["content", "mimetype"], paths: ["/upload"]
+  plug :match
+  plug :dispatch
 
-  plug(
-    VerifyRequest,
-    fields: ["content", "mimetype"],
-    paths: ["/upload"]
-  )
+  get "/" do
+    send_resp(conn, 200, "Welcome")
+  end
 
-  plug(:match)
-  plug(:dispatch)
+  get "/upload" do
+    send_resp(conn, 201, "Uploaded")
+  end
 
-  get("/", do: send_resp(conn, 200, "Welcome\n"))
-  get("/upload", do: send_resp(conn, 201, "Uploaded\n"))
-  match(_, do: send_resp(conn, 404, "Oops!\n"))
+  match _ do
+    send_resp(conn, 404, "Oops!")
+  end
 
   defp handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
-    IO.puts "Kind:"
-    IO.inspect kind
-    IO.puts "Reason:"
-    IO.inspect reason
-    IO.puts "Stack"
-    IO.inspect stack
+    IO.inspect(kind, label: :kind)
+    IO.inspect(reason, label: :reason)
+    IO.inspect(stack, label: :stack)
     send_resp(conn, conn.status, "Something went wrong")
   end
 end
@@ -455,12 +464,9 @@ end
 如果這時候查看終端機，將看到如下內容：
 
 ```shell
-Kind:
-:error
-Reason:
-%Example.Plug.VerifyRequest.IncompleteRequestError{message: ""}
-Stack
-[
+kind: :error
+reason: %Example.Plug.VerifyRequest.IncompleteRequestError{message: ""}
+stack: [
   {Example.Plug.VerifyRequest, :verify_request!, 2,
    [file: 'lib/example/plug/verify_request.ex', line: 23]},
   {Example.Plug.VerifyRequest, :call, 2,


### PR DESCRIPTION
Small PR just to clean a few things in favor of readability:

1. Removed `( )` from the plug calls as this is not as common in the wild. The standard .formatter.exs for Plug exempts these calls as well.
1. Multi-lined all the routes for readability.  Single line and no spaces between definitions makes things run together.