### PR TITLE
Improve the page-shown moment: hide sidebar until skel detects screen size 

### DIFF
--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -104,9 +104,11 @@
 				skel
 					.on('+large', function() {
 						$sidebar.addClass('inactive');
+						$sidebar.css('visibility', 'visible');
 					})
 					.on('-large !large', function() {
 						$sidebar.removeClass('inactive');
+						$sidebar.css('visibility', 'visible');
 					});
 
 			// Hack: Workaround for Chrome/Android scrollbar position bug.

--- a/_assets/stylesheets/layout/_sidebar.scss
+++ b/_assets/stylesheets/layout/_sidebar.scss
@@ -41,6 +41,8 @@
 			'box-shadow 0.5s ease'
 		));
 		background-color: _palette(bg-alt);
+		// Hide until skel detects screen size
+		visibility: hidden;
 		font-size: 1em;
 		position: relative;
 		width: _size(sidebar-width);


### PR DESCRIPTION
On mobile, the sidebar is shown for a moment on changing page.

![page-shown-moment](https://user-images.githubusercontent.com/16313897/57206832-c68f3e80-7003-11e9-9a78-7ae78177fca3.gif)

This PR resolves the problem by hiding sidebar until `skel` detects screen width.
