### PR TITLE
Some spelling/consistency mistakes

### DIFF
--- a/en/lessons/basics/mix-tasks.md
+++ b/en/lessons/basics/mix-tasks.md
@@ -79,7 +79,7 @@ Within this file, let's insert these 7 lines of Elixir.
 defmodule Mix.Tasks.Hello do
   use Mix.Task
 
-  @shortdoc "Simply runs the Hello.say/0 function"
+  @shortdoc "Simply calls the Hello.say/0 function."
   def run(_) do
     # calling our Hello.say() function from earlier
     Hello.say()

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -291,7 +291,7 @@ With a "belongs to" relationship, we can leverage Ecto's `build_assoc/3` functio
 * The name of the association.
 * Any attributes we want to assign to the associated record we are saving.
 
-Let's save a movie and and associated character. First, we'll create a movie record:
+Let's save a movie and an associated character. First, we'll create a movie record:
 
 ```elixir
 iex> alias Example.{Movie, Character, Repo}

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -18,7 +18,7 @@ We can perform simple queries directly against our `Example.Repo` with the help 
 
 We can use the `Repo.get/3` function to fetch a record from the database given its ID. This function requires two arguments: a "queryable" data structure and the ID of a record to retrieve from the database. It returns a struct describing the record found, if any. It returns `nil` if no such record is found.
 
-Let's take a look at an example. Below, we'll get the movie with and ID of 1:
+Let's take a look at an example. Below, we'll get the movie with an ID of 1:
 
 ```elixir
 iex> alias Example.{Repo, Movie}

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -164,7 +164,7 @@ pipeline :maybe_browser_auth do
 end
 
 pipeline :ensure_authed_access do
-  plug(Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler})
+  plug(Guardian.Plug.EnsureAuthenticated, %{"type" => "access", handler: MyApp.HttpErrorHandler})
 end
 ```
 

--- a/en/lessons/libraries/guardian.md
+++ b/en/lessons/libraries/guardian.md
@@ -164,7 +164,7 @@ pipeline :maybe_browser_auth do
 end
 
 pipeline :ensure_authed_access do
-  plug(Guardian.Plug.EnsureAuthenticated, %{"type" => "access", handler: MyApp.HttpErrorHandler})
+  plug(Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler})
 end
 ```
 


### PR DESCRIPTION
Some small spelling/consistency mistakes.

_About `mix-tasks.md`_
The example says:
```
@shortdoc "Simply runs the Hello.say/0 function"
```

And the output later shows:
```
mix hello             # Simply calls the Hello.say/0 function.
```

So I fixed the first one to look like the second one.