### PR TITLE
Change uniq_by to simpler uniq

### DIFF
--- a/en/lessons/basics/enum.md
+++ b/en/lessons/basics/enum.md
@@ -195,11 +195,11 @@ iex> Enum.sort([%{:count => 4}, %{:count => 1}])
 [%{count: 1}, %{count: 4}]
 ```
 
-### uniq_by
+### uniq
 
-We can use `uniq_by/2` to remove duplicates from our enumerables:
+We can use `uniq/1` to remove duplicates from our enumerables:
 
 ```elixir
-iex> Enum.uniq_by([1, 2, 3, 2, 1, 1, 1, 1, 1], fn x -> x end)
+iex> Enum.uniq([1, 2, 3, 2, 1, 1, 1, 1, 1])
 [1, 2, 3]
 ```

--- a/en/lessons/basics/enum.md
+++ b/en/lessons/basics/enum.md
@@ -203,3 +203,12 @@ We can use `uniq/1` to remove duplicates from our enumerables:
 iex> Enum.uniq([1, 2, 3, 2, 1, 1, 1, 1, 1])
 [1, 2, 3]
 ```
+
+### uniq_by
+
+`uniq_by/2` also removes duplicates from enumerables, but it allows us to provide a function to do the uniqueness comparison.
+
+```elixir
+iex> Enum.uniq_by([%{x: 1, y: 1}, %{x: 2, y: 1}, %{x: 3, y: 3}], fn coord -> coord.y end)
+[%{x: 1, y: 1}, %{x: 3, y: 3}]
+```


### PR DESCRIPTION
`uniq/1` is simpler than `uniq_by/2`, though the latter is more flexible. I think simplicity wins for these guides. We can also mention both.