### PR TITLE
Specify that Map update operator syntax only works for existing keys

### DIFF
--- a/en/lessons/basics/collections.md
+++ b/en/lessons/basics/collections.md
@@ -185,3 +185,19 @@ iex> map = %{foo: "bar", hello: "world"}
 iex> %{map | foo: "baz"}
 %{foo: "baz", hello: "world"}
 ```
+
+**Note**: this syntax only works for updating a key that already exists in the map! If the key does not exist, a `KeyError` will be raised.
+
+To create a new key, instead use [`Map.put/3`](https://hexdocs.pm/elixir/Map.html#put/3)
+
+```elixir
+iex> map = %{hello: "world"}
+%{hello: "world"}
+iex> %{map | foo: "baz"}
+** (KeyError) key :foo not found in: %{hello: "world"}
+    (stdlib) :maps.update(:foo, "baz", %{hello: "world"})
+    (stdlib) erl_eval.erl:259: anonymous fn/2 in :erl_eval.expr/5
+    (stdlib) lists.erl:1263: :lists.foldl/3
+iex> Map.put(map, :foo, "baz")
+%{foo: "baz", hello: "world"}
+```

--- a/en/lessons/basics/collections.md
+++ b/en/lessons/basics/collections.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.5
+version: 1.3.0
 title: Collections
 ---
 


### PR DESCRIPTION
Add a note and example that Map update operator only works to update an _existing_ key, and an example to use Map.put/3 for a new key instead.