### PR TITLE
mistype in it/basics/basics

### DIFF
--- a/it/lessons/basics/basics.md
+++ b/it/lessons/basics/basics.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Base
 ---
 
@@ -228,7 +228,7 @@ iex> 2 <= 3
 true
 ```
 
-Per una comparazione rigorosa (_strict_) tra interi e numeri in virogla mobile, usa `===`:
+Per una comparazione rigorosa (_strict_) tra interi e numeri in virgola mobile, usa `===`:
 
 ```elixir
 iex> 2 == 2.0


### PR DESCRIPTION
Fixed a mistype in the it/basics/basics markdown file

```
virogla -> virgola
```

I also  updated the patch version as requested in contributing:
```
1.2.0 -> 1.2.1
```