### PR TITLE
Add a unique index for the one to many relation

### DIFF
--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -128,7 +128,7 @@ We'll define the `Distributor` migration and schema with the "belongs to" relati
 mix ecto.gen.migration create_distributors
 ```
 
-We should add a foreign key of `movie_id` to the `distributors` table migration we just generated:
+We should add a foreign key of `movie_id` to the `distributors` table migration we just generated as well as a unique index to enforce that a movie has only one distributor:
 
 ```elixir
 # priv/repo/migrations/*_create_distributors.exs
@@ -141,6 +141,8 @@ defmodule Example.Repo.Migrations.CreateDistributors do
       add :name, :string
       add :movie_id, references(:movies)
     end
+    
+    create unique_index(:distributors, [:movie_id])
   end
 end
 ```

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.2.0
 title: Associations
 ---
 


### PR DESCRIPTION
It could make sense to include a unique index on :movie_id on the distributors table as there may only be one for each movie.