### PR TITLE
Fixed output of IEx for Structs from # to %

### DIFF
--- a/_posts/2018-10-10-ecto-multi.md
+++ b/_posts/2018-10-10-ecto-multi.md
@@ -19,7 +19,7 @@ Everything starts with a `%Multi{}` struct. You can create a new Multi calling t
 
 ```elixir
 iex> Ecto.Multi.new()
-%Ecto.Multi{names: #MapSet<[]>, operations: []}
+%Ecto.Multi{names: %MapSet<[]>, operations: []}
 ```
 
 ## Executing Multi operations

--- a/_posts/2019-03-25-til-ecto-validations-and-constraints.md
+++ b/_posts/2019-03-25-til-ecto-validations-and-constraints.md
@@ -77,7 +77,7 @@ iex> %User{} |> User.changeset(%{})
     email: {"can't be blank", [validation: :required]},
     password: {"can't be blank", [validation: :required]}
   ],
-  data: #MyCoolWebApp.Accounts.User<>,
+  data: %MyCoolWebApp.Accounts.User<>,
   valid?: false
 >
 ```
@@ -177,7 +177,7 @@ iex> user |> User.changeset(attrs) |> Repo.insert()
      email: {"has already been taken",
       [constraint: :unique, constraint_name: "users_email_index"]}
    ],
-   data: #MyCoolWebApp.Accounts.User<>,
+   data: %MyCoolWebApp.Accounts.User<>,
    valid?: false
  >}
 ```

--- a/_posts/2019-03-25-til-ecto-validations-and-constraints.md
+++ b/_posts/2019-03-25-til-ecto-validations-and-constraints.md
@@ -69,7 +69,7 @@ And for free, Ecto adds descriptive errors to our changeset:
 
 ```elixir
 iex> %User{} |> User.changeset(%{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [
@@ -109,7 +109,7 @@ iex> attrs = %{display_name: "prince", email: "prince@test.com", password: "supe
 iex> user |> User.changeset(attrs) |> Repo.insert()
 {:ok,
  %MyCoolWebApp.Accounts.User{
-   __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
+   __meta__: %Ecto.Schema.Metadata<:loaded, "users">,
    display_name: "prince",
    email: "prince@test.com",
    id: 1,
@@ -128,7 +128,7 @@ iex> attrs = %{display_name: "prince", email: "prince@test.com", password: "supe
 iex> user |> User.changeset(attrs) |> Repo.insert()
 {:ok,
  %MyCoolWebApp.Accounts.User{
-   __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
+   __meta__: %Ecto.Schema.Metadata<:loaded, "users">,
    display_name: "prince",
    email: "prince@test.com",
    id: 2,
@@ -165,7 +165,7 @@ iex> user = %User{}
 iex> attrs = %{display_name: "prince", email: "prince@test.com", password: "super_secret"}
 iex> user |> User.changeset(attrs) |> Repo.insert()
 {:error,
- #Ecto.Changeset<
+ %Ecto.Changeset<
    action: :insert,
    changes: %{
      display_name: "prince",

--- a/_posts/2019-08-23-til-ecto-select-merge.md
+++ b/_posts/2019-08-23-til-ecto-select-merge.md
@@ -99,7 +99,7 @@ iex> admission = Repo.get(Admission, 1)
 iex> AdmissionEvent.for_admission(admission) |> Repo.all()
 [
   %Registrar.Tracking.AdmissionEvent{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "admission_events">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "admission_events">,
     action: "Student Admitted",
     admission_id: 3,
     admitter_uuid: "7edd4d7f-a790-41f9-b4ef-16f1dc3b33ea",
@@ -154,11 +154,11 @@ iex> admission = Repo.get(Admission, 1)
 iex> events = AdmissionEvent.for_admission(admission) |> Repo.all() |> Repo.preload(:admitter)
 [
   %Registrar.Tracking.AdmissionEvent{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "admission_events">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "admission_events">,
     action: "Student Admitted",
     admission_id: 3,
     admitter: %Registrar.User{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "users">,
       id: 1,
       name: "Albus Dumbledore",
       uuid: "7edd4d7f-a790-41f9-b4ef-16f1dc3b33ea"
@@ -226,7 +226,7 @@ iex> admission = Repo.get(Admission, 1)
 iex> AdmissionEvent.for_admission(admission) |> Repo.all()
 [
   %Registrar.Tracking.AdmissionEvent{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "admission_events">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "admission_events">,
     action: "Student Admitted",
     admission_id: 3,
     admitter_name: "Albus Dumbledore",

--- a/bn/lessons/basics/modules.md
+++ b/bn/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: মডিউল
 ---
 
@@ -77,29 +77,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 স্ট্রাক্টকে আমরা ঠিক ম্যাপের মতই আপডেট করতে পারি-
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 স্ট্রাক্টকে আপনি ম্যাপের সাথে ম্যাচ করাতে পারেন-
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## কম্পোজিশান

--- a/de/lessons/basics/modules.md
+++ b/de/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.1
+version: 0.9.2
 title: Module
 ---
 
@@ -75,29 +75,29 @@ Lass uns ein paar structs erstellen:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Wir können ein struct genauso wie eine map aktualisieren:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Und das Wichtigste: Man kann sie gegen maps matchen:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Komposition

--- a/en/lessons/basics/modules.md
+++ b/en/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Modules
 ---
 
@@ -83,29 +83,29 @@ Let's create some structs:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 We can update our struct just like we would a map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Most importantly, you can match structs against maps:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 As of Elixir 1.8 structs include custom introspection.
@@ -113,7 +113,7 @@ To understand what this means and how we are to use it let us inspect our `sean`
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 All of our fields are present which is okay for this example but what if we had a protected field we didn't want to include?
@@ -133,9 +133,9 @@ With our updated module in place let's take a look at what happens in `iex`:
 
 ```elixir
 iex> sean = %Example.User{name: "Sean"}
-#Example.User<name: "Sean", ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 The `roles` are excluded from output!

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Associations
 ---
 
@@ -403,7 +403,7 @@ Next up, we'll create a changeset for our movie record:
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -411,11 +411,11 @@ Now we'll pass our changeset as the first argument to [`Ecto.Changeset.put_assoc
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+      %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -455,11 +455,11 @@ We can use this same approach to create a brand new actor that is associated wit
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -301,9 +301,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -319,7 +319,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -327,7 +327,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -342,7 +342,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -350,7 +350,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -370,14 +370,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -437,7 +437,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -479,7 +479,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -300,7 +300,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -317,7 +317,7 @@ Now we'll build our associated character and insert it into the database:
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -325,7 +325,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -340,7 +340,7 @@ In order to use `build_assoc/3` to save a movie's associated distributor, we tak
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -348,7 +348,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -368,14 +368,14 @@ Assuming we already have the movie record we created above, let's create an acto
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -389,7 +389,7 @@ First, note that in order to work with changesets, we need to make sure that our
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -432,10 +432,10 @@ Lastly, we'll update the given movie and actor records using our latest changese
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -474,10 +474,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -403,7 +403,7 @@ Next up, we'll create a changeset for our movie record:
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Example.Movie<>,
  valid?: true>
 ```
 
@@ -416,11 +416,11 @@ iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actor
   changes: %{
     actors: [
       %Ecto.Changeset<action: :update, changes: %{}, errors: [],
-       data: #Example.Actor<>, valid?: true>
+       data: %Example.Actor<>, valid?: true>
     ]
   },
   errors: [],
-  data: #Example.Movie<>,
+  data: %Example.Movie<>,
   valid?: true
 >
 ```
@@ -463,13 +463,13 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],
-        data: #Example.Actor<>,
+        data: %Example.Actor<>,
         valid?: true
       >
     ]
   },
   errors: [],
-  data: #Example.Movie<>,
+  data: %Example.Movie<>,
   valid?: true
 >
 iex>  Repo.update!(changeset)

--- a/en/lessons/ecto/changesets.md
+++ b/en/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Changesets
 ---
 
@@ -18,7 +18,7 @@ Let's look at an empty `%Changeset{}` struct:
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 As you can see, it has some potentially useful fields, but they are all empty.
@@ -43,7 +43,7 @@ To create a changeset using the `Person` schema, we are going to use `Ecto.Chang
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -54,7 +54,7 @@ The third parameter is what makes `cast/4` special: it is a list of fields allow
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:name, :age])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -63,7 +63,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -76,7 +76,7 @@ Now we can create changesets, but since we do not have validation, any changes t
 
 ```elixir
 iex> Ecto.Changeset.change(%Friends.Person{name: "Bob"}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: nil},
   errors: [],
@@ -131,7 +131,7 @@ Note: do not forget to run `recompile()` when working in `iex`, otherwise it won
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -158,7 +158,7 @@ You can try and guess what the result would be if we pass a name that consists o
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -221,7 +221,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -265,7 +265,7 @@ Now we don't have to pass a `name` and `Anonymous` would be automatically set, a
 
 ```elixir
 iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],

--- a/en/lessons/ecto/changesets.md
+++ b/en/lessons/ecto/changesets.md
@@ -43,7 +43,7 @@ To create a changeset using the `Person` schema, we are going to use `Ecto.Chang
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -58,12 +58,12 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -80,7 +80,7 @@ iex> Ecto.Changeset.change(%Friends.Person{name: "Bob"}, %{"name" => ""})
   action: nil,
   changes: %{name: nil},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```
@@ -135,7 +135,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -165,7 +165,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "A"})
     name: {"should be at least %{count} character(s)",
      [count: 2, validation: :length, kind: :min, type: :string]}
   ],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -225,7 +225,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -269,7 +269,7 @@ iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -105,7 +105,7 @@ When using `from` with a query expression, the first argument must be a value th
 
 ```elixir
 iex> query = select(Movie, [m], m)
-#Ecto.Query<from m in Example.Movie, select: m>
+%Ecto.Query<from m in Example.Movie, select: m>
 iex> Repo.all(query)
 
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
@@ -130,7 +130,7 @@ We use the `Ecto.Query.select/3` function to specify the select statement portio
 
 ```elixir
 iex> query = select(Movie, [:title])
-#Ecto.Query<from m in Example.Movie, select: [:title]>
+%Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
@@ -155,7 +155,7 @@ The second approach behaves a little differently. This time, we *do* need to use
 
 ```elixir
 iex(15)> query = from(m in Movie, select: m.title)
-#Ecto.Query<from m in Example.Movie, select: m.title>
+%Ecto.Query<from m in Example.Movie, select: m.title>
 iex(16)> Repo.all(query)
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
@@ -170,7 +170,7 @@ We can use `where` expressions to include "where" clauses in our queries. Multip
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One")
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
@@ -191,7 +191,7 @@ We can use `where` expressions together with `select`:
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
 iex> Repo.all(query)
 
 15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
@@ -206,7 +206,7 @@ In order to use interpolated values or Elixir expressions in our where clauses, 
 iex> title = "Ready Player One"
 "Ready Player One"
 iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
+%Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
 
@@ -222,7 +222,7 @@ First, we'll write a query expression using the `first/2` function:
 
 ```elixir
 iex> first(Movie)
-#Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
+%Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
 ```
 
 Then we pass our query to the `Repo.one/2` function to get our result:

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: Querying
 ---
 
@@ -24,7 +24,7 @@ Let's take a look at an example. Below, we'll get the movie with an ID of 1:
 iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -45,7 +45,7 @@ iex> alias Example.Repo
 iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -79,7 +79,7 @@ iex> Repo.all(query)
 14:58:03.187 [debug] QUERY OK source="movies" db=1.7ms decode=4.2ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -111,7 +111,7 @@ iex> Repo.all(query)
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -136,7 +136,7 @@ iex> Repo.all(query)
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -176,7 +176,7 @@ iex> Repo.all(query)
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -232,7 +232,7 @@ iex> Movie |> first() |> Repo.one()
 
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -275,16 +275,16 @@ iex> Repo.all(from m in Movie, preload: [:actors])
 13:17:28.357 [debug] QUERY OK source="actors" db=2.4ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -312,16 +312,16 @@ iex> Repo.all(query)
 13:18:52.053 [debug] QUERY OK source="movies" db=3.7ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -354,7 +354,7 @@ We can also preload the associated schemas of records that have already been que
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -364,16 +364,16 @@ iex> movie = Repo.get(Movie, 1)
 }
 iex> movie = Repo.preload(movie, :actors)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
@@ -393,13 +393,13 @@ Now we can ask a movie for its actors:
 iex> movie.actors
 [
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -25,9 +25,9 @@ iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -46,9 +46,9 @@ iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -80,9 +80,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -112,9 +112,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -137,9 +137,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: nil,
     tagline: nil,
     title: "Ready Player One"
@@ -177,9 +177,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -233,9 +233,9 @@ iex> Movie |> first() |> Repo.one()
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -259,7 +259,7 @@ Let's take a look to see what happens when we try to ask a movie for its associa
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 iex> movie.actors
-#Ecto.Association.NotLoaded<association :actors is not loaded>
+%Ecto.Association.NotLoaded<association :actors is not loaded>
 ```
 
 We _can't_ access those associated characters unless we preload them. There are a few different way to preload records with Ecto.
@@ -280,18 +280,18 @@ iex> Repo.all(from m in Movie, preload: [:actors])
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -317,18 +317,18 @@ iex> Repo.all(query)
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -355,9 +355,9 @@ We can also preload the associated schemas of records that have already been que
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -369,18 +369,18 @@ iex> movie = Repo.preload(movie, :actors)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ], # actors are LOADED!!
   characters: [],
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -395,13 +395,13 @@ iex> movie.actors
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"
   }
 ]

--- a/es/lessons/basics/modules.md
+++ b/es/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Composición
 ---
 
@@ -80,36 +80,36 @@ Ahora, creemos estructuras:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Podemos actualizar una estructura justo como lo hacemos con un mapa:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Algo muy importante es que podemos hacer coincidencia entre estructuras y mapas:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 A partir de Elixir 1.8 las estructuras incluyen la inspección personalizada.
 Para entender que significa esto y cómo debemos usarlo, debemos inspeccionar el mapa `sean`:
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 Todos nuestros campos están presentes, lo que esta bien para este ejemplo, pero ¿qué pasaría si tuviéramos un campo protegido que no quisiéramos incluir?
@@ -128,10 +128,10 @@ Nota: también podríamos usar `@derive {Inspect, except: [:roles]}`, son equiva
 Con nuestro módulo actualizado, echemos un vistazo a lo que sucede en `iex`:
 
 ```elixir
-iex> sean = #Example.User<name: "Sean", roles: [...], ...>
-#Example.User<name: "Sean", ...>
+iex> sean = %Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 Los `roles` son excluidos de la salida.

--- a/fr/lessons/basics/modules.md
+++ b/fr/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.3.1
 title: Modules
 ---
 
@@ -77,29 +77,29 @@ Créons maintenant quelques struct:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Nous pouvons mettre à jour notre struct exactement comme une map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Plus important encore, on peut pattern matcher struct et map:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Composition

--- a/gr/lessons/basics/modules.md
+++ b/gr/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Ενότητες
 ---
 
@@ -83,29 +83,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Μπορούμε να αναβαθμίσουμε μια δομή όπως θα το κάναμε σε ένα χάρτη:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Σημαντικότερα, μπορούμε να αντιπαραβάλουμε δομές με χάρτες:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Από την Elixir 1.8 οι δομές περιλαμβάνουν προσαρμοσμένη προεπισκόπηση.
@@ -113,7 +113,7 @@ iex> %{name: "Sean"} = sean
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 Όλα τα πεδία μας είναι παρόντα, το οποίο αρκεί για αυτό το παράδειγμα, αλλά τι θα συνέβαινε αν είχαμε ένα προστατευόμενο πεδίο που δεν θέλαμε να συμπεριλάβουμε;
@@ -133,9 +133,9 @@ _Σημείωση_: θα μπορούσαμε επίσης να χρησιμοπ
 
 ```elixir
 iex> sean = %Example.User{name: "Sean"}
-#Example.User<name: "Sean", ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 Οι ρόλοι δεν συμπεριλαμβάνονται πλέον στην έξοδο!

--- a/id/lessons/basics/modules.md
+++ b/id/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: Composition
 ---
 
@@ -77,29 +77,29 @@ Mari buat beberapa struct:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Kita bisa mengubah struct seperti pada map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Lebih penting lagi, anda bisa mencocokkan struct terhadap map:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Composition

--- a/it/lessons/basics/modules.md
+++ b/it/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Moduli
 ---
 
@@ -77,29 +77,29 @@ Creaiamo qualche struttura:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Possiamo aggiornare la nostra struttura come faremmo con una mappa:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Soprattutto, possiamo combinare le strutture con le mappe:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 A partire da Elixir 1.8, le strutture includono una nuova funzionalità di introspezione personalizzata.
@@ -107,7 +107,7 @@ Per capire meglio cosa significhi e come usarlo, ispezioniamo il risultato di `s
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 Tutti i parametri della struttura sono presenti che in questo caso va bene, ma se volessimo un parametro protetto che non dovrebbe essere incluso?
@@ -126,10 +126,10 @@ _Nota_: potremo pure usare `@derive {Inspect, except: [:roles]}`, sono equivalen
 Con il modulo aggiornato, ora vediamo cosa succede in `iex`:
 
 ```elixir
-iex> sean = #Example.User<name: "Sean", roles: [...], ...>
-#Example.User<name: "Sean", ...>
+iex> sean = %Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 Il parametri `roles` è escluso dall'output!

--- a/ja/lessons/basics/modules.md
+++ b/ja/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: モジュール
 ---
 
@@ -83,29 +83,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 構造体はあたかもマップのように更新することができます:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 最も重要なことですが、構造体はマップに対してマッチすることができます:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Elixir 1.8以降、構造体にカスタムイントロスペクション機能が追加されました。
@@ -114,7 +114,7 @@ Elixir 1.8以降、構造体にカスタムイントロスペクション機能�
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 この例では全てのフィールドが出力対象になっていますが、出力したくない項目がある場合、どのようにしたら良いでしょうか？
@@ -134,9 +134,9 @@ end
 
 ```elixir
 iex> sean = %Example.User{name: "Sean"}
-#Example.User<name: "Sean", ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 `roles` が出力から除外されました!

--- a/ja/lessons/ecto/associations.md
+++ b/ja/lessons/ecto/associations.md
@@ -299,7 +299,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -316,7 +316,7 @@ iex> movie = Repo.insert!(movie)
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -324,7 +324,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -339,7 +339,7 @@ Repo.insert!(character)
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -347,7 +347,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -367,14 +367,14 @@ iex> Repo.insert!(distributor)
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -388,7 +388,7 @@ iex> actor = Repo.insert!(actor)
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -431,10 +431,10 @@ iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actor
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -473,10 +473,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/ja/lessons/ecto/associations.md
+++ b/ja/lessons/ecto/associations.md
@@ -300,9 +300,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -318,7 +318,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -326,7 +326,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -341,7 +341,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -349,7 +349,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -369,14 +369,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -436,7 +436,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -478,7 +478,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/ja/lessons/ecto/associations.md
+++ b/ja/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: アソシエーション
 ---
 
@@ -402,7 +402,7 @@ iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -410,11 +410,11 @@ iex> movie_changeset = Ecto.Changeset.change(movie)
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+      %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -454,11 +454,11 @@ iex> Repo.update!(movie_actors_changeset)
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/ja/lessons/ecto/changesets.md
+++ b/ja/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: チェンジセット
 ---
 
@@ -19,7 +19,7 @@ Ectoは `Changeset` モジュールとデータ構造体という形で、デー
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 見ての通り、便利そうなフィールドがいくつかありますが、全て空になっています。
@@ -44,7 +44,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -55,7 +55,7 @@ Ectoは構造体そのものに基づいてスキーマを見つけることが�
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:name, :age])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -64,7 +64,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -77,7 +77,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => ""}, [:name, :age])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: nil},
   errors: [],
@@ -132,7 +132,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -159,7 +159,7 @@ nameに対して1つの文字を渡した場合、どのような結果になる
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -222,7 +222,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -266,7 +266,7 @@ end
 
 ```elixir
 iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],

--- a/ja/lessons/ecto/changesets.md
+++ b/ja/lessons/ecto/changesets.md
@@ -44,7 +44,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -59,12 +59,12 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -81,7 +81,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => ""}, [:name, 
   action: nil,
   changes: %{name: nil},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```
@@ -136,7 +136,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -226,7 +226,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -270,7 +270,7 @@ iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```

--- a/ja/lessons/ecto/querying.md
+++ b/ja/lessons/ecto/querying.md
@@ -105,7 +105,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = select(Movie, [m], m)
-#Ecto.Query<from m in Example.Movie, select: m>
+%Ecto.Query<from m in Example.Movie, select: m>
 iex> Repo.all(query)
 
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
@@ -130,7 +130,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(Movie, select: [:title])
-#Ecto.Query<from m in Example.Movie, select: [:title]>
+%Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
@@ -155,7 +155,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex(15)> query = from(m in Movie, select: m.title)
-#Ecto.Query<from m in Example.Movie, select: m.title>
+%Ecto.Query<from m in Example.Movie, select: m.title>
 iex(16)> Repo.all(query)
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
@@ -170,7 +170,7 @@ iex(16)> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One")
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
@@ -191,7 +191,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
 iex> Repo.all(query)
 
 15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
@@ -206,7 +206,7 @@ where句において埋め込み値やElixirの式を使うためには、 `^` �
 iex> title = "Ready Player One"
 "Ready Player One"
 iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
+%Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
 
@@ -222,7 +222,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> first(Movie)
-#Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
+%Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
 ```
 
 次に、そのクエリを `Repo.one/2` 関数に渡して結果を取得します:

--- a/ja/lessons/ecto/querying.md
+++ b/ja/lessons/ecto/querying.md
@@ -25,9 +25,9 @@ iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -46,9 +46,9 @@ iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -80,9 +80,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -112,9 +112,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -137,9 +137,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: nil,
     tagline: nil,
     title: "Ready Player One"
@@ -177,9 +177,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -233,9 +233,9 @@ iex> Movie |> first() |> Repo.one()
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -259,7 +259,7 @@ iex> Movie |> last() |> Repo.one()
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 iex> movie.actors
-#Ecto.Association.NotLoaded<association :actors is not loaded>
+%Ecto.Association.NotLoaded<association :actors is not loaded>
 ```
 
 プリロードしない限り、それらの関連したデータにアクセスすることはできません。Ectoを使ってレコードをプリロードするにはいくつかの方法があります。
@@ -279,18 +279,18 @@ iex> Repo.all(from m in Movie, preload: [:actors])
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -314,18 +314,18 @@ iex> Repo.all(query)
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -352,9 +352,9 @@ joinステートメントについて、もっと詳細を見てみましょう�
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -366,18 +366,18 @@ iex> movie = Repo.preload(movie, :actors)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ], # actors are LOADED!!
   characters: [],
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -392,13 +392,13 @@ iex> movie.actors
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"
   }
 ]

--- a/ja/lessons/ecto/querying.md
+++ b/ja/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: クエリ
 ---
 
@@ -24,7 +24,7 @@ Postgresデータベースのようなデータストアに対してマップす
 iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -45,7 +45,7 @@ iex> alias Example.Repo
 iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -79,7 +79,7 @@ iex> Repo.all(query)
 14:58:03.187 [debug] QUERY OK source="movies" db=1.7ms decode=4.2ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -111,7 +111,7 @@ iex> Repo.all(query)
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -136,7 +136,7 @@ iex> Repo.all(query)
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -176,7 +176,7 @@ iex> Repo.all(query)
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -232,7 +232,7 @@ iex> Movie |> first() |> Repo.one()
 
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -274,16 +274,16 @@ Ecto.Query
 iex> Repo.all(from m in Movie, preload: [:actors])
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -309,16 +309,16 @@ iex> query = from(m in Movie, join: a in assoc(m, :actors), preload: [actors: a]
 iex> Repo.all(query)
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -351,7 +351,7 @@ joinステートメントについて、もっと詳細を見てみましょう�
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -361,16 +361,16 @@ iex> movie = Repo.get(Movie, 1)
 }
 iex> movie = Repo.preload(movie, :actors)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
@@ -390,13 +390,13 @@ iex> movie = Repo.preload(movie, :actors)
 iex> movie.actors
 [
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"

--- a/ko/lessons/basics/modules.md
+++ b/ko/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: 모듈
 ---
 
@@ -77,29 +77,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 구조체의 내용도 맵과 같은 방법으로 변경할 수 있습니다.
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 여기서 제일 중요한 부분은, 맵에 대해서도 구조체를 매칭할 수 있다는 점입니다.
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## 컴포지션

--- a/ms/lessons/basics/modules.md
+++ b/ms/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: Komposisi
 ---
 
@@ -77,29 +77,29 @@ Mari kita bina beberapa struct:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Kita boleh mengemaskini struct sebagaimana kita mengemaskini map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Paling penting, anda boleh membuat padanan antara struct dan map:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Komposisi

--- a/no/lessons/basics/modules.md
+++ b/no/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.1
+version: 0.9.2
 title: Moduler
 ---
 
@@ -77,22 +77,22 @@ La oss lage noen structs:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Vi kan oppdatere vår struct akkurat som med en map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Det viktigste er at du kan matche structs mot maps:

--- a/pl/lessons/basics/modules.md
+++ b/pl/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 0.9.1
 title: Organizacja kodu
 ---
 
@@ -77,29 +77,29 @@ Stwórzmy zatem kilka struktur:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Struktury można aktualizować tak jak zwykłe mapy:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 I najważniejsze. Struktury można dopasowywać tak jak zwykłe mapy:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Komponenty

--- a/pt/lessons/basics/modules.md
+++ b/pt/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Módulos
 ---
 
@@ -77,29 +77,29 @@ Vamos criar algumas structs:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Podemos atualizar nosso struct apenas como se fosse um mapa:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Mais importante, você pode associar estruturas contra mapas:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 A partir do Elixir 1.8, structs incluem introspecção customizáveis.
@@ -107,7 +107,7 @@ Para entender o que isso significa e como devemos usar, vamos inspecionar nossa 
 
  ```elixir
  iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 Todos os campos estão presentes, o que está correto para esse exemplo, mas o que acontece se tivéssemos um campo protegido que não gostaríamos de incluir? A nova funcionalidade `@derive` faz com que possamos alcançar isso! Vamos atualizar nosso exemplo para que `roles` não seja mais incluído na nossa saída:
@@ -125,9 +125,9 @@ Com o nosso módulo já atualizado, vamos ver o que acontece no `iex`:
 
 ```elixir
 iex> sean = %Example.User{name: "Sean"}
-#Example.User<name: "Sean", ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 Os `roles` não são mais exibidos na saída!

--- a/pt/lessons/ecto/associations.md
+++ b/pt/lessons/ecto/associations.md
@@ -301,7 +301,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -318,7 +318,7 @@ Agora vamos construir nosso personagem associado e inseri-lo no banco de dados:
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -326,7 +326,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -341,7 +341,7 @@ Para usar `build_assoc/3` com o intuito de salvar o distribuidor associado a um 
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -349,7 +349,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -369,14 +369,14 @@ Supondo que já tenhamos o registro do filme que criamos acima, vamos criar um r
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -390,7 +390,7 @@ Primeiro, note que para trabalhar com Changesets, precisamos ter certeza de que 
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
   %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -433,10 +433,10 @@ Por fim, atualizaremos os registros de filme e ator fornecidos usando nosso chan
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -475,10 +475,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/pt/lessons/ecto/associations.md
+++ b/pt/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 title: Associações
 ---
 
@@ -404,7 +404,7 @@ Em seguida, criaremos um conjunto de alterações para nosso registro de filme:
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -412,11 +412,11 @@ Agora vamos passar nosso changeset como o primeiro argumento para [`Ecto.Changes
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+       %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -456,11 +456,11 @@ Podemos usar essa mesma abordagem para criar um novo ator associado ao filme em 
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/pt/lessons/ecto/associations.md
+++ b/pt/lessons/ecto/associations.md
@@ -302,9 +302,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -320,7 +320,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -328,7 +328,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -343,7 +343,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -351,7 +351,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -371,14 +371,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -438,7 +438,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -480,7 +480,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/pt/lessons/ecto/changesets.md
+++ b/pt/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Changesets
 ---
 
@@ -19,7 +19,7 @@ Vamos ver uma estrutura `%Changeset{}` vazia:
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 Como você pode ver, tem alguns campos potencialmente úteis, mas estão todos vazios.
@@ -43,7 +43,7 @@ Para criar um changeset usando o schema `User`, vamos usar `Ecto.Changeset.cast/
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{}, [:name])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
  ```
 
@@ -54,7 +54,7 @@ O terceiro parâmetro é o que faz o `cast/4` especial: é uma lista de campos p
 
  ```elixir
  iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [:name])
- #Ecto.Changeset<
+ %Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -63,7 +63,7 @@ O terceiro parâmetro é o que faz o `cast/4` especial: é uma lista de campos p
 >
 
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
 ```
 
@@ -76,7 +76,7 @@ Agora podemos criar changesets, mas como não temos validação, quaisquer alter
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => ""}, [:name])
-#Ecto.Changeset<
+%Ecto.Changeset<
  action: nil,
  changes: %{name: ""},
  errors: [],
@@ -130,7 +130,7 @@ Nota: não esqueça de executar `recompile()` quando estiver trabalhando no `iex
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -157,7 +157,7 @@ Você pode tentar adivinhar qual seria o resultado se passássemos um nome que c
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -220,7 +220,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -264,7 +264,7 @@ Agora nós não temos que passar um `name`, e `Anonymous` será definido automat
 
 ```elixir
 iex> User.registration_changeset(%User{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],

--- a/pt/lessons/ecto/querying.md
+++ b/pt/lessons/ecto/querying.md
@@ -25,9 +25,9 @@ iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -46,9 +46,9 @@ iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -80,9 +80,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -112,9 +112,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -137,9 +137,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: nil,
     tagline: nil,
     title: "Ready Player One"
@@ -177,9 +177,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -233,9 +233,9 @@ iex> Movie |> first() |> Repo.one()
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -259,7 +259,7 @@ Vamos dar uma olhada para ver o que acontece quando tentamos perguntar os atores
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 iex> movie.actors
-#Ecto.Association.NotLoaded<association :actors is not loaded>
+%Ecto.Association.NotLoaded<association :actors is not loaded>
 ```
 
 _Não podemos_ acessar esses atores associados, a menos que os pré-carregemos. Existem algumas maneiras diferentes de pré-carregar registros com o Ecto.
@@ -279,18 +279,18 @@ iex> Repo.all(from m in Movie, preload: [:actors])
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -314,18 +314,18 @@ iex> Repo.all(query)
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -352,9 +352,9 @@ Também podemos pré-carregar os esquemas associados de registros que já foram 
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -366,18 +366,18 @@ iex> movie = Repo.preload(movie, :actors)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ], # actors are LOADED!!
   characters: [],
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -392,13 +392,13 @@ iex> movie.actors
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"
   }
 ]

--- a/pt/lessons/ecto/querying.md
+++ b/pt/lessons/ecto/querying.md
@@ -105,7 +105,7 @@ Ao usar `from` com uma expressão de consulta, o primeiro argumento deve ser um 
 
 ```elixir
 iex> query = select(Movie, [m], m)
-#Ecto.Query<from m in Example.Movie, select: m>
+%Ecto.Query<from m in Example.Movie, select: m>
 iex> Repo.all(query)
 
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
@@ -130,7 +130,7 @@ Usamos a função `Ecto.Query.select/3` para especificar a parte da instrução 
 
 ```elixir
 iex> query = from(Movie, select: [:title])                                            
-#Ecto.Query<from m in Example.Movie, select: [:title]>
+%Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
@@ -155,7 +155,7 @@ A segunda abordagem se comporta de maneira um pouco diferente. Desta vez, nós *
 
 ```elixir
 iex(15)> query = from(m in Movie, select: m.title)   
-#Ecto.Query<from m in Example.Movie, select: m.title>
+%Ecto.Query<from m in Example.Movie, select: m.title>
 iex(16)> Repo.all(query)                             
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
@@ -170,7 +170,7 @@ Podemos usar expressões `where` para incluir cláusulas `where` em nossas consu
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One")                   
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
@@ -191,7 +191,7 @@ Podemos usar expressões `where` junto com `select`:
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
 iex> Repo.all(query)
 
 15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
@@ -206,7 +206,7 @@ Para usar valores interpolados ou expressões Elixir em nossas cláusulas where,
 iex> title = "Ready Player One"
 "Ready Player One"
 iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)            
-#Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
+%Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
 
@@ -222,7 +222,7 @@ Primeiro, vamos escrever uma expressão de consulta usando a função `first/2`:
 
 ```elixir
 iex> first(Movie)
-#Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
+%Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
 ```
 
 Então passamos nossa consulta para a função `Repo.one/2` para obter nosso resultado:

--- a/pt/lessons/ecto/querying.md
+++ b/pt/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: Querying
 ---
 
@@ -24,7 +24,7 @@ Vamos dar uma olhada em um exemplo. Abaixo, vamos pegar o filme com o ID 1:
 iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -45,7 +45,7 @@ iex> alias Example.Repo
 iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -79,7 +79,7 @@ iex> Repo.all(query)
 14:58:03.187 [debug] QUERY OK source="movies" db=1.7ms decode=4.2ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -111,7 +111,7 @@ iex> Repo.all(query)
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -136,7 +136,7 @@ iex> Repo.all(query)
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -176,7 +176,7 @@ iex> Repo.all(query)
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -232,7 +232,7 @@ iex> Movie |> first() |> Repo.one()
 
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -274,16 +274,16 @@ Ecto.Query
 iex> Repo.all(from m in Movie, preload: [:actors])
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -309,16 +309,16 @@ iex> query = from(m in Movie, join: a in assoc(m, :actors), preload: [actors: a]
 iex> Repo.all(query)  
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -351,7 +351,7 @@ Também podemos pré-carregar os esquemas associados de registros que já foram 
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -361,16 +361,16 @@ iex> movie = Repo.get(Movie, 1)
 }
 iex> movie = Repo.preload(movie, :actors)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
@@ -390,13 +390,13 @@ Agora podemos pedir um filme para seus atores:
 iex> movie.actors
 [
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"

--- a/ru/lessons/basics/modules.md
+++ b/ru/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: Модули
 ---
 
@@ -82,36 +82,36 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Обновление структуры работает так же, как и обновление ассоциативного массива:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Что еще более важно, структуры можно сопоставлять с ассоциативными массивами:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Начиная с Elixir 1.8 структуры включают в себя пользовательскую интроспекцию. Чтобы понять, что она значит и как следует её использовать, давайте выведем значение переменной `sean`:
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 В выводе видны все наши поля, что, конечно, хорошо для примера, но что если у нас есть защищённое поле, которое мы не хотим показывать?
@@ -130,10 +130,10 @@ _Примечание_: также можно использовать `@derive 
 После обновления модуля давайте посмотрим, что сейчас будет происходить в `iex`:
 
 ```elixir
-iex> sean = #Example.User<name: "Sean", roles: [...], ...>
-#Example.User<name: "Sean", ...>
+iex> sean = %Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 Ключ `roles` больше не показывается в выводе!

--- a/ru/lessons/ecto/associations.md
+++ b/ru/lessons/ecto/associations.md
@@ -299,7 +299,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -316,7 +316,7 @@ iex> movie = Repo.insert!(movie)
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -324,7 +324,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -339,7 +339,7 @@ Repo.insert!(character)
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -347,7 +347,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -367,14 +367,14 @@ iex> Repo.insert!(distributor)
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -388,7 +388,7 @@ iex> actor = Repo.insert!(actor)
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -431,10 +431,10 @@ iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actor
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -473,10 +473,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/ru/lessons/ecto/associations.md
+++ b/ru/lessons/ecto/associations.md
@@ -300,9 +300,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -318,7 +318,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -326,7 +326,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -341,7 +341,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -349,7 +349,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -369,14 +369,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -436,7 +436,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -478,7 +478,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/ru/lessons/ecto/associations.md
+++ b/ru/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Связи
 ---
 
@@ -402,7 +402,7 @@ iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -410,11 +410,11 @@ iex> movie_changeset = Ecto.Changeset.change(movie)
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+      %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -454,11 +454,11 @@ iex> Repo.update!(movie_actors_changeset)
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/ru/lessons/ecto/changesets.md
+++ b/ru/lessons/ecto/changesets.md
@@ -43,7 +43,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -58,12 +58,12 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: %Friends.Person<>,
  valid?: true>
 ```
 
@@ -80,7 +80,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => ""}, [:name, 
   action: nil,
   changes: %{name: nil},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```
@@ -135,7 +135,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -165,7 +165,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "A"})
     name: {"should be at least %{count} character(s)",
      [count: 2, validation: :length, kind: :min, type: :string]}
   ],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -224,7 +224,7 @@ iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: false
 >
 ```
@@ -268,7 +268,7 @@ iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
   action: nil,
   changes: %{name: "Аноним"},
   errors: [],
-  data: #Friends.Person<>,
+  data: %Friends.Person<>,
   valid?: true
 >
 ```

--- a/ru/lessons/ecto/changesets.md
+++ b/ru/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Наборы изменений
 ---
 
@@ -18,7 +18,7 @@ Ecto полностью покрывает эту потребность при 
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 Как можно заметить, здесь присутствуют некоторые потенциально полезные поля, но все они пусты.
@@ -43,7 +43,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{}, [:name, :age])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -54,7 +54,7 @@ Ecto самостоятельно найдёт схему, соответств�
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:name, :age])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -63,7 +63,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [:na
 >
 
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Friends.Person<>,
  valid?: true>
 ```
 
@@ -76,7 +76,7 @@ iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => "Jack"}, [])
 
 ```elixir
 iex> Ecto.Changeset.cast(%Friends.Person{name: "Bob"}, %{"name" => ""}, [:name, :age])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: nil},
   errors: [],
@@ -131,7 +131,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -158,7 +158,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -220,7 +220,7 @@ end
 
 ```elixir
 iex> Friends.Person.changeset(%Friends.Person{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -264,7 +264,7 @@ end
 
 ```elixir
 iex> Friends.Person.registration_changeset(%Friends.Person{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Аноним"},
   errors: [],

--- a/sk/lessons/basics/modules.md
+++ b/sk/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.3.1
 title: Moduly
 ---
 
@@ -77,29 +77,29 @@ Teraz si vytvorme niekoľko príkladov tohto structu:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Struct môžeme meniť rovnako, ako mapu:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Veľmi dôležitou vlastnosťou structov je, že ich môžeme pattern matchovať s mapami:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Kompozícia

--- a/tr/lessons/basics/modules.md
+++ b/tr/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Modüller
 ---
 
@@ -76,29 +76,29 @@ Yapılar yaratalım:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Yapıyı tıpkı bir harita gibi güncelleyebiliriz:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 En önemlisi haritalarla yapılara erişebilirsiniz:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Birleştirme (Composition)

--- a/uk/lessons/basics/modules.md
+++ b/uk/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.3.1
 title: Композиція
 ---
 
@@ -77,29 +77,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Оновлення структури працює так само, як і оновлення асоціативного масиву:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Що ще більш важливо, структури можна зіставляти з асоціативними масивами:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Композиція

--- a/vi/lessons/basics/modules.md
+++ b/vi/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.1
+version: 0.9.2
 title: Modules
 ---
 
@@ -79,29 +79,29 @@ Hãy cùng tạo một vài structs:
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 Chúng ta cũng có thể cập nhật struct giống như chúng ta làm với một map:
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 Quan trọng nhất, chúng ta có thể so trùng mẫu struct với map:
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 ## Composition

--- a/zh-hans/lessons/basics/modules.md
+++ b/zh-hans/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: 模块（Module）
 ---
 
@@ -78,36 +78,36 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 我们也可以像更新映射（map）那样更新结构体：
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 更重要的是：结构体可以匹配映射（maps）：
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 到了 Elixir 1.8，结构体允许包含自定义的检查方式。以下通过查看 `sean` 结构来理解这是如何实现的：
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 在这里例子，结构体里面所有的字段都展示出来并没有问题。但是，如果我们想排除一些保护字段呢？新的 `@derive` 功能就能实现这点了。如下修改一下样例中的 `roles` 字段，它就不会包含在输出里面了：
@@ -125,9 +125,9 @@ _备注_：我们也可以使用 `@derive {Inspect, except: [:roles]}`，效果�
 
 ```elixir
 iex> sean = %Example.User{name: "Sean"}
-#Example.User<name: "Sean", ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 `roles` 字段排除在外了！

--- a/zh-hans/lessons/ecto/associations.md
+++ b/zh-hans/lessons/ecto/associations.md
@@ -301,7 +301,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -318,7 +318,7 @@ iex> movie = Repo.insert!(movie)
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -326,7 +326,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -341,7 +341,7 @@ Repo.insert!(character)
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})       
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -349,7 +349,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -369,14 +369,14 @@ iex> Repo.insert!(distributor)
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -390,7 +390,7 @@ iex> actor = Repo.insert!(actor)
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -433,10 +433,10 @@ iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actor
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -475,10 +475,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/zh-hans/lessons/ecto/associations.md
+++ b/zh-hans/lessons/ecto/associations.md
@@ -302,9 +302,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -320,7 +320,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -328,7 +328,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -343,7 +343,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -351,7 +351,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -371,14 +371,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -438,7 +438,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -480,7 +480,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/zh-hans/lessons/ecto/associations.md
+++ b/zh-hans/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: 关联关系
 ---
 
@@ -404,7 +404,7 @@ iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)                                                    
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -412,11 +412,11 @@ iex> movie_changeset = Ecto.Changeset.change(movie)
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+      %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -456,11 +456,11 @@ iex> Repo.update!(movie_actors_changeset)
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])                      
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/zh-hans/lessons/ecto/changesets.md
+++ b/zh-hans/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Changesets
 ---
 
@@ -17,7 +17,7 @@ Ecto 提供了一个有关数据更改的完整解决方案，Ecto 将相关的�
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 正如你所看到的，它有一些可能有用的字段，但它们都是空的。
@@ -40,7 +40,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{}, [:name])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
  ```
 
@@ -48,7 +48,7 @@ iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{}, [:name])
 
  ```elixir
  iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [:name])
- #Ecto.Changeset<
+ %Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -57,7 +57,7 @@ iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{}, [:name])
 >
 
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
 ```
 
@@ -69,7 +69,7 @@ iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [])
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => ""}, [:name])
-#Ecto.Changeset<
+%Ecto.Changeset<
  action: nil,
  changes: %{name: ""},
  errors: [],
@@ -122,7 +122,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -148,7 +148,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -211,7 +211,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -256,7 +256,7 @@ end
 
 ```elixir
 iex> User.registration_changeset(%User{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],

--- a/zh-hans/lessons/ecto/querying.md
+++ b/zh-hans/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: 查询
 ---
 
@@ -23,7 +23,7 @@ title: 查询
 iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -44,7 +44,7 @@ iex> alias Example.Repo
 iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -78,7 +78,7 @@ iex> Repo.all(query)
 14:58:03.187 [debug] QUERY OK source="movies" db=1.7ms decode=4.2ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -110,7 +110,7 @@ iex> Repo.all(query)
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -135,7 +135,7 @@ iex> Repo.all(query)
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -175,7 +175,7 @@ iex> Repo.all(query)
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -231,7 +231,7 @@ iex> Movie |> first() |> Repo.one()
 
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -273,16 +273,16 @@ Ecto.Query
 iex> Repo.all(from m in Movie, preload: [:actors])
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -308,16 +308,16 @@ iex> query = from(m in Movie, join: a in assoc(m, :actors), preload: [actors: a]
 iex> Repo.all(query)  
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -350,7 +350,7 @@ Repo.all from m in Movie,
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -360,16 +360,16 @@ iex> movie = Repo.get(Movie, 1)
 }
 iex> movie = Repo.preload(movie, :actors)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
@@ -389,13 +389,13 @@ iex> movie = Repo.preload(movie, :actors)
 iex> movie.actors
 [
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"

--- a/zh-hans/lessons/ecto/querying.md
+++ b/zh-hans/lessons/ecto/querying.md
@@ -24,9 +24,9 @@ iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -45,9 +45,9 @@ iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -79,9 +79,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -111,9 +111,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -136,9 +136,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: nil,
     tagline: nil,
     title: "Ready Player One"
@@ -176,9 +176,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -232,9 +232,9 @@ iex> Movie |> first() |> Repo.one()
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -258,7 +258,7 @@ iex> Movie |> last() |> Repo.one()
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 iex> movie.actors
-#Ecto.Association.NotLoaded<association :actors is not loaded>
+%Ecto.Association.NotLoaded<association :actors is not loaded>
 ```
 
 我们 _无法_ 访问那些关联的角色除非我们预加载它们。有几种不同的使用 Ecto 预加载记录的方式。
@@ -278,18 +278,18 @@ iex> Repo.all(from m in Movie, preload: [:actors])
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -313,18 +313,18 @@ iex> Repo.all(query)
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -351,9 +351,9 @@ Repo.all from m in Movie,
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -365,18 +365,18 @@ iex> movie = Repo.preload(movie, :actors)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ], # actors are LOADED!!
   characters: [],
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -391,13 +391,13 @@ iex> movie.actors
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"
   }
 ]

--- a/zh-hans/lessons/ecto/querying.md
+++ b/zh-hans/lessons/ecto/querying.md
@@ -104,7 +104,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = select(Movie, [m], m)
-#Ecto.Query<from m in Example.Movie, select: m>
+%Ecto.Query<from m in Example.Movie, select: m>
 iex> Repo.all(query)
 
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
@@ -129,7 +129,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(Movie, select: [:title])                                            
-#Ecto.Query<from m in Example.Movie, select: [:title]>
+%Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
@@ -154,7 +154,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex(15)> query = from(m in Movie, select: m.title)   
-#Ecto.Query<from m in Example.Movie, select: m.title>
+%Ecto.Query<from m in Example.Movie, select: m.title>
 iex(16)> Repo.all(query)                             
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
@@ -169,7 +169,7 @@ iex(16)> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One")                   
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
@@ -190,7 +190,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
 iex> Repo.all(query)
 
 15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
@@ -205,7 +205,7 @@ iex> Repo.all(query)
 iex> title = "Ready Player One"
 "Ready Player One"
 iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)            
-#Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
+%Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
 
@@ -221,7 +221,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> first(Movie)
-#Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
+%Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
 ```
 
 然后我们把这个查询语句传给 `Repo.one/2` 函数来获取结果：

--- a/zh-hant/lessons/basics/modules.md
+++ b/zh-hant/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.4.1
 title: 模組
 ---
 
@@ -83,29 +83,29 @@ end
 
 ```elixir
 iex> %Example.User{}
-#Example.User<name: "Sean", roles: [], ...>
+%Example.User<name: "Sean", roles: [], ...>
 
 iex> %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [], ...>
+%Example.User<name: "Steve", roles: [], ...>
 
 iex> %Example.User{name: "Steve", roles: [:manager]}
-#Example.User<name: "Steve", roles: [:manager]>
+%Example.User<name: "Steve", roles: [:manager]>
 ```
 
 我們可以像更新映射一樣更新結構體：
 
 ```elixir
 iex> steve = %Example.User{name: "Steve"}
-#Example.User<name: "Steve", roles: [...], ...>
+%Example.User<name: "Steve", roles: [...], ...>
 iex> sean = %{steve | name: "Sean"}
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 最重要的是，你可以將結構體與映射配對：
 
 ```elixir
 iex> %{name: "Sean"} = sean
-#Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", roles: [...], ...>
 ```
 
 自 Elixir 1.8 開始，結構體加入自定自我訓練(introspection)。
@@ -113,7 +113,7 @@ iex> %{name: "Sean"} = sean
 
 ```elixir
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", roles: [...], ...>"
+"%Example.User<name: \"Sean\", roles: [...], ...>"
 ```
 
 將所有欄位都呈現，以這個例子是可以的，但是如果我們有一個不希望被包括的受保護欄位呢？
@@ -132,10 +132,10 @@ _註_：也可以使用 `@derive {Inspect, except: [:roles]}`，它們是同樣�
 隨著更新後的模組就位，現在來看看 `iex` 中會發生什麼：
 
 ```elixir
-iex> sean = #Example.User<name: "Sean", roles: [...], ...>
-#Example.User<name: "Sean", ...>
+iex> sean = %Example.User<name: "Sean", roles: [...], ...>
+%Example.User<name: "Sean", ...>
 iex> inspect(sean)
-"#Example.User<name: \"Sean\", ...>"
+"%Example.User<name: \"Sean\", ...>"
 ```
 
 `roles` 已被排除在輸出中！

--- a/zh-hant/lessons/ecto/associations.md
+++ b/zh-hant/lessons/ecto/associations.md
@@ -298,7 +298,7 @@ iex> alias Example.{Movie, Character, Repo}
 iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video games"}
 
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:built, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:built, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -315,7 +315,7 @@ iex> movie = Repo.insert!(movie)
 ```elixir
 character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:built, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -323,7 +323,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 }
 Repo.insert!(character)
 %Example.Character{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "characters">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -338,7 +338,7 @@ Repo.insert!(character)
 ```elixir
 iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:built, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -346,7 +346,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 }
 iex> Repo.insert!(distributor)
 %Example.Distributor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "distributors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
   movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
@@ -366,14 +366,14 @@ iex> Repo.insert!(distributor)
 iex> alias Example.Actor
 iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:built, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
   movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
@@ -387,7 +387,7 @@ iex> actor = Repo.insert!(actor)
 ```elixir
 iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [],
   characters: [],
   distributor: nil,
@@ -430,10 +430,10 @@ iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actor
 ```elixir
 iex> Repo.update!(movie_actors_changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
@@ -472,10 +472,10 @@ iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "
 >
 iex>  Repo.update!(changeset)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"

--- a/zh-hant/lessons/ecto/associations.md
+++ b/zh-hant/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: 關聯關係
 ---
 
@@ -401,7 +401,7 @@ iex> movie = Repo.preload(movie, [:distributor, :characters, :actors])
 
 ```elixir
 iex> movie_changeset = Ecto.Changeset.change(movie)
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Example.Movie<>,
  valid?: true>
 ```
 
@@ -409,11 +409,11 @@ iex> movie_changeset = Ecto.Changeset.change(movie)
 
 ```elixir
 iex> movie_actors_changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [actor])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<action: :update, changes: %{}, errors: [],
+      %Ecto.Changeset<action: :update, changes: %{}, errors: [],
        data: #Example.Actor<>, valid?: true>
     ]
   },
@@ -453,11 +453,11 @@ iex> Repo.update!(movie_actors_changeset)
 
 ```elixir
 iex> changeset = movie_changeset |> Ecto.Changeset.put_assoc(:actors, [%{name: "Gary"}])
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{
     actors: [
-      #Ecto.Changeset<
+      %Ecto.Changeset<
         action: :insert,
         changes: %{name: "Gary"},
         errors: [],

--- a/zh-hant/lessons/ecto/associations.md
+++ b/zh-hant/lessons/ecto/associations.md
@@ -299,9 +299,9 @@ iex> movie = %Movie{title: "Ready Player One", tagline: "Something about video g
 
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:built, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: nil,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -317,7 +317,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -325,7 +325,7 @@ Repo.insert!(character)
 %Example.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Wade Watts"
 }
@@ -340,7 +340,7 @@ iex> distributor = Ecto.build_assoc(movie, :distributor, %{name: "Netflix"})
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:built, "distributors">,
   id: nil,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -348,7 +348,7 @@ iex> Repo.insert!(distributor)
 %Example.Distributor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "distributors">,
   id: 1,
-  movie: #Ecto.Association.NotLoaded<association :movie is not loaded>,
+  movie: %Ecto.Association.NotLoaded<association :movie is not loaded>,
   movie_id: 1,
   name: "Netflix"
 }
@@ -368,14 +368,14 @@ iex> actor = %Actor{name: "Tyler Sheridan"}
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:built, "actors">,
   id: nil,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 iex> actor = Repo.insert!(actor)
 %Example.Actor{
   __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
   id: 1,
-  movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+  movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
   name: "Tyler Sheridan"
 }
 ```
@@ -435,7 +435,7 @@ iex> Repo.update!(movie_actors_changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     }
   ],
@@ -477,7 +477,7 @@ iex>  Repo.update!(changeset)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ],

--- a/zh-hant/lessons/ecto/changesets.md
+++ b/zh-hant/lessons/ecto/changesets.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: 變更集 (Changesets)
 ---
 
@@ -18,7 +18,7 @@ Ecto 提供一個完整的解決方案，以 `Changeset` 模組的形式處理�
 
 ```elixir
 iex> %Ecto.Changeset{}
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>
 ```
 
 如你所見，它有一些可能有用的欄位，但它們目前都是空的。
@@ -42,7 +42,7 @@ end
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{}, [:name])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
  ```
 
@@ -53,7 +53,7 @@ Ecto 足夠聰明，可以根據結構體本身找到結構描述。
 
 ```elixir
  iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [:name])
- #Ecto.Changeset<
+ %Ecto.Changeset<
   action: nil,
   changes: %{name: "Jack"},
   errors: [],
@@ -62,7 +62,7 @@ Ecto 足夠聰明，可以根據結構體本身找到結構描述。
 >
 
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [])
-#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
+%Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #User<>,
  valid?: true>
 ```
 
@@ -75,7 +75,7 @@ iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => "Jack"}, [])
 
 ```elixir
 iex> Ecto.Changeset.cast(%User{name: "Bob"}, %{"name" => ""}, [:name])
-#Ecto.Changeset<
+%Ecto.Changeset<
  action: nil,
  changes: %{name: ""},
  errors: [],
@@ -129,7 +129,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => ""})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{},
   errors: [name: {"can't be blank", [validation: :required]}],
@@ -156,7 +156,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "A"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "A"},
   errors: [
@@ -219,7 +219,7 @@ end
 
 ```elixir
 iex> User.changeset(%User{}, %{"name" => "Bob"})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Bob"},
   errors: [name: {"is not a superhero", []}],
@@ -263,7 +263,7 @@ end
 
 ```elixir
 iex> User.registration_changeset(%User{}, %{})
-#Ecto.Changeset<
+%Ecto.Changeset<
   action: nil,
   changes: %{name: "Anonymous"},
   errors: [],

--- a/zh-hant/lessons/ecto/querying.md
+++ b/zh-hant/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: 查詢
 ---
 
@@ -24,7 +24,7 @@ title: 查詢
 iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -45,7 +45,7 @@ iex> alias Example.Repo
 iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -79,7 +79,7 @@ iex> Repo.all(query)
 14:58:03.187 [debug] QUERY OK source="movies" db=1.7ms decode=4.2ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -111,7 +111,7 @@ iex> Repo.all(query)
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -136,7 +136,7 @@ iex> Repo.all(query)
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -176,7 +176,7 @@ iex> Repo.all(query)
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
     characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
     distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -232,7 +232,7 @@ iex> Movie |> first() |> Repo.one()
 
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -274,16 +274,16 @@ Ecto.Query
 iex> Repo.all(from m in Movie, preload: [:actors])
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -309,16 +309,16 @@ iex> query = from(m in Movie, join: a in assoc(m, :actors), preload: [actors: a]
 iex> Repo.all(query)
 [
   %Example.Movie{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
     actors: [
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
-        __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+        __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
         movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
@@ -351,7 +351,7 @@ Repo.all from m in Movie,
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
   characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
   distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
@@ -361,16 +361,16 @@ iex> movie = Repo.get(Movie, 1)
 }
 iex> movie = Repo.preload(movie, :actors)
 %Example.Movie{
-  __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+  __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
   actors: [
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
-      __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+      __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
       movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
@@ -390,13 +390,13 @@ iex> movie = Repo.preload(movie, :actors)
 iex> movie.actors
 [
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
-    __meta__: #Ecto.Schema.Metadata<:loaded, "actors">,
+    __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
     movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"

--- a/zh-hant/lessons/ecto/querying.md
+++ b/zh-hant/lessons/ecto/querying.md
@@ -105,7 +105,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = select(Movie, [m], m)
-#Ecto.Query<from m in Example.Movie, select: m>
+%Ecto.Query<from m in Example.Movie, select: m>
 iex> Repo.all(query)
 
 06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
@@ -130,7 +130,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(Movie, select: [:title])
-#Ecto.Query<from m in Example.Movie, select: [:title]>
+%Ecto.Query<from m in Example.Movie, select: [:title]>
 iex> Repo.all(query)
 
 15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
@@ -155,7 +155,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex(15)> query = from(m in Movie, select: m.title)
-#Ecto.Query<from m in Example.Movie, select: m.title>
+%Ecto.Query<from m in Example.Movie, select: m.title>
 iex(16)> Repo.all(query)
 
 15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
@@ -170,7 +170,7 @@ iex(16)> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One")
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
 iex> Repo.all(query)
 
 15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
@@ -191,7 +191,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
 iex> Repo.all(query)
 
 15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
@@ -206,7 +206,7 @@ iex> Repo.all(query)
 iex> title = "Ready Player One"
 "Ready Player One"
 iex> query = from(m in Movie, where: m.title == ^title, select: m.tagline)
-#Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
+%Ecto.Query<from m in Example.Movie, where: m.title == ^"Ready Player One",
  select: m.tagline>
 iex> Repo.all(query)
 
@@ -222,7 +222,7 @@ iex> Repo.all(query)
 
 ```elixir
 iex> first(Movie)
-#Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
+%Ecto.Query<from m in Example.Movie, order_by: [desc: m.id], limit: 1>
 ```
 
 然後將查詢傳遞給 `Repo.one/2` 函數以獲得結果：

--- a/zh-hant/lessons/ecto/querying.md
+++ b/zh-hant/lessons/ecto/querying.md
@@ -25,9 +25,9 @@ iex> alias Example.{Repo, Movie}
 iex> Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -46,9 +46,9 @@ iex> alias Example.Movie
 iex> Repo.get_by(Movie, title: "Ready Player One")
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -80,9 +80,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -112,9 +112,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -137,9 +137,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: nil,
     tagline: nil,
     title: "Ready Player One"
@@ -177,9 +177,9 @@ iex> Repo.all(query)
 [
   %Example.Movie{
     __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -233,9 +233,9 @@ iex> Movie |> first() |> Repo.one()
 06:36:14.234 [debug] QUERY OK source="movies" db=3.7ms
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -259,7 +259,7 @@ iex> Movie |> last() |> Repo.one()
 ```elixir
 iex> movie = Repo.get(Movie, 1)
 iex> movie.actors
-#Ecto.Association.NotLoaded<association :actors is not loaded>
+%Ecto.Association.NotLoaded<association :actors is not loaded>
 ```
 
 _不能_ 存取那些相關的角色，除非預載它們。而使用 Ecto 預載記錄有幾種不同的方法。
@@ -279,18 +279,18 @@ iex> Repo.all(from m in Movie, preload: [:actors])
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -314,18 +314,18 @@ iex> Repo.all(query)
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 1,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Bob"
       },
       %Example.Actor{
         __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
         id: 2,
-        movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+        movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
         name: "Gary"
       }
     ],
-    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
     id: 1,
     tagline: "Something about video games",
     title: "Ready Player One"
@@ -352,9 +352,9 @@ Repo.all from m in Movie,
 iex> movie = Repo.get(Movie, 1)
 %Example.Movie{
   __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-  actors: #Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
-  characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  actors: %Ecto.Association.NotLoaded<association :actors is not loaded>, # actors are NOT LOADED!!
+  characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -366,18 +366,18 @@ iex> movie = Repo.preload(movie, :actors)
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 1,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Bob"
     },
     %Example.Actor{
       __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
       id: 2,
-      movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+      movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
       name: "Gary"
     }
   ], # actors are LOADED!!
   characters: [],
-  distributor: #Ecto.Association.NotLoaded<association :distributor is not loaded>,
+  distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
   id: 1,
   tagline: "Something about video games",
   title: "Ready Player One"
@@ -392,13 +392,13 @@ iex> movie.actors
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 1,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Bob"
   },
   %Example.Actor{
     __meta__: %Ecto.Schema.Metadata<:loaded, "actors">,
     id: 2,
-    movies: #Ecto.Association.NotLoaded<association :movies is not loaded>,
+    movies: %Ecto.Association.NotLoaded<association :movies is not loaded>,
     name: "Gary"
   }
 ]


### PR DESCRIPTION

Fixed the output of iex where Structs were prefixed with `#` instead of `%` in some files.

Related Issue: #2071 

List of structs that I found had the problem.
 - Example.User
 - Echo.Changeset
 - Ecto.Schema.Metadata
 - Ecto.Association.NotLoaded
 - Ecto.Query
 - Friends.Person
 - Example.Movie
 - Example.Actor
 - MyCoolWebApp.Accounts.User

I think I have covered all of them, let me know if there are any missing.
Also I have not tried each one of them in IEx, but assumed every Struct needs this fix. 
Mostly because I'm yet to complete my basics tutorials, so didn't know how to import Ecto.

Made sure to update the version of every file edited. 
Incremented only the PATCH part of it.

> Note: I have also edited posts, but I'm not sure If I should do that.

