### PR TITLE
hides last commit option in report page for now

### DIFF
--- a/_includes/report.html
+++ b/_includes/report.html
@@ -12,7 +12,7 @@
         <th>{{ headers['original_version'] }}</th>
         <th>{{ headers['translation_version'] }}</th>
         <th>{{ headers['version_severity'] }}</th>
-        <th>{{ headers['last_commit'] }}</th>
+        <!-- <th>{{ headers['last_commit'] }}</th> -->
       </tr>
     </thead>
     <tbody>
@@ -32,15 +32,15 @@
           <td class="version-cell" title="{{ lesson[1]['translated_severity'] }}">
             <div class="version-difference-indicator version-difference-{{ lesson[1]['version_severity'] }}"></div>
           </td>
-          <td>
-              {% if lesson[1]['last_commit'] == '' %}
-              {% else %}
-              <a class="icon" href="{{ lesson[1]['last_commit'] }}">
-                  <i class="fa fa-github-square"></i>
-                  <span class="label">{{ headers['last_commit'] }}</span>
-              </a>
-              {% endif %}
-          </td>
+          <!-- <td> -->
+          <!-- {% if lesson[1]['last_commit'] == '' %} -->
+          <!-- {% else %} -->
+          <!-- <a class="icon" href="{{ lesson[1]['last_commit'] }}"> -->
+          <!-- <i class="fa fa-github-square"></i> -->
+          <!-- <span class="label">{{ headers['last_commit'] }}</span> -->
+          <!-- </a> -->
+          <!-- {% endif %} -->
+          <!-- </td> -->
         </tr>
         {% endfor %}
       {% endfor %}

--- a/_includes/report.html
+++ b/_includes/report.html
@@ -12,7 +12,6 @@
         <th>{{ headers['original_version'] }}</th>
         <th>{{ headers['translation_version'] }}</th>
         <th>{{ headers['version_severity'] }}</th>
-        <!-- <th>{{ headers['last_commit'] }}</th> -->
       </tr>
     </thead>
     <tbody>
@@ -32,15 +31,6 @@
           <td class="version-cell" title="{{ lesson[1]['translated_severity'] }}">
             <div class="version-difference-indicator version-difference-{{ lesson[1]['version_severity'] }}"></div>
           </td>
-          <!-- <td> -->
-          <!-- {% if lesson[1]['last_commit'] == '' %} -->
-          <!-- {% else %} -->
-          <!-- <a class="icon" href="{{ lesson[1]['last_commit'] }}"> -->
-          <!-- <i class="fa fa-github-square"></i> -->
-          <!-- <span class="label">{{ headers['last_commit'] }}</span> -->
-          <!-- </a> -->
-          <!-- {% endif %} -->
-          <!-- </td> -->
         </tr>
         {% endfor %}
       {% endfor %}


### PR DESCRIPTION
I only hide it for now, until we move the service to a server who can leverage this option.