### PR TITLE
use the correct categories for posts

### DIFF
--- a/_posts/2019-05-06-live-view-with-presence.md
+++ b/_posts/2019-05-06-live-view-with-presence.md
@@ -1,7 +1,7 @@
 ---
 author: Sophie DeBenedetto
 author_link: https://github.com/sophiedebenedetto
-categories: post
+categories: general
 date: 2019-05-21
 layout: post
 title:  Tracking Users in a Chat App with LiveView, PubSub Presence

--- a/_posts/2019-06-04-live-view-with-channels.md
+++ b/_posts/2019-06-04-live-view-with-channels.md
@@ -1,7 +1,7 @@
 ---
 author: Sophie DeBenedetto
 author_link: https://github.com/sophiedebenedetto
-categories: post
+categories: general
 date: 2019-06-04
 layout: post
 title:  Using Channels with LiveView for Better UX

--- a/_posts/2019-08-23-til-ecto-select-merge.md
+++ b/_posts/2019-08-23-til-ecto-select-merge.md
@@ -1,7 +1,7 @@
 ---
 author: Kate Travers
 author_link: https://github.com/ktravers
-categories: post
+categories: til
 tags: ['ecto']
 date: 2019-08-23
 layout: post

--- a/_posts/2019-09-12-elixirconf-2019-review.md
+++ b/_posts/2019-09-12-elixirconf-2019-review.md
@@ -1,7 +1,7 @@
 ---
 author: Sophie DeBenedetto
 author_link: https://github.com/sophiedebenedetto
-categories: post
+categories: general
 tags: ['conferences']
 date: 2019-09-08
 layout: post

--- a/_posts/2019-09-15-releasing-an-umbrella-app-with-docker-and-mix-release.md
+++ b/_posts/2019-09-15-releasing-an-umbrella-app-with-docker-and-mix-release.md
@@ -1,7 +1,7 @@
 ---
 author: Sophie DeBenedetto
 author_link: https://github.com/sophiedebenedetto
-categories: post
+categories: general
 tags: ['docker', 'mix release', 'config', 'umbrella apps']
 date: 2019-09-20
 layout: post

--- a/_posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
+++ b/_posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
@@ -1,7 +1,7 @@
 ---
 author: Sophie DeBenedetto
 author_link: https://github.com/sophiedebenedetto
-categories: post
+categories: general
 tags: ['live view']
 date: 2019-10-20
 layout: post


### PR DESCRIPTION
This resolves https://github.com/elixirschool/elixirschool/issues/2087

![elixir_school](https://user-images.githubusercontent.com/10033856/67471397-a0ac3380-f64f-11e9-89e6-137e9f12b9ad.png)

The main cause was that the category in the post does not exist inside of

https://github.com/elixirschool/elixirschool/blob/master/_data/blog-meta.yml#L1

which means that in 
https://github.com/elixirschool/elixirschool/blob/master/blog-archive-categories.html#L21

it tries to apply the blog metadata but it can't find it, so based on how
https://github.com/elixirschool/elixirschool/blob/master/_includes/function-getCategoryMeta#L1
works it will keep the metadata context of the previous item it looped over ( in this case it was til).

I dabbled a bit with defaulting a name if it does not exist, but because the loop is based on how the present keys whether it exists or not, I'd have to do a more significant overhaul of how it builds the page.
So I figured I'd rather deal with that separately if it's even something you guys care about