### PR TITLE
[ES] Update Ecto/basics

### DIFF
--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -173,7 +173,7 @@ $ mix ecto.migrate
 Now that we've created our initial table we need to tell Ecto more about it, part of how we do that is through schemas.
 A schema is a module that defines mappings to the underlying database table's fields.
 
-While Ecto favors pluralize database table names, the schema is typically singular, so we'll create a `Person` schema to accomplany our table.
+While Ecto favors pluralize database table names, the schema is typically singular, so we'll create a `Person` schema to accompany our table.
 
 Let's create our new schema at `lib/friends/person.ex`:
 

--- a/es/lessons/ecto/basics.md
+++ b/es/lessons/ecto/basics.md
@@ -28,8 +28,8 @@ A través de esta lección cubriremos tres partes de Ecto:
 Para empezar crearemos una aplicación con su árbol de supervisión.
 
 ```shell
-$ mix new amigos --sup
-$ cd amigos
+$ mix new friends --sup
+$ cd friends
 ```
 
 Agrega los paquetes de ecto y postgrex a tu archivo `mix.exs`
@@ -57,42 +57,42 @@ Toda comunicación con la base de datos se hará usando este repositorio.
 Configura un repositorio ejecutando:
 
 ```shell
-$ mix ecto.gen.repo -r Amigos.Repo
+$ mix ecto.gen.repo -r Friends.Repo
 ```
 
 Esto generará la configuración requerida en `config/config.exs` para conectarse a la base de datos, incluyendo el adaptador que usará.
-Este es el archivo de configuración de nuestra aplicación `Amigos`
+Este es el archivo de configuración de nuestra aplicación `Friends`
 
 ```elixir
-config :amigos, Amigos.Repo,
-  database: "amigos_repo",
-  usernombre: "postgres",
+config :friends, Friends.Repo,
+  database: "friends_repo",
+  username: "postgres",
   password: "",
-  hostnombre: "localhost"
+  hostname: "localhost"
 ```
 
 Esto configura como Ecto se conectará a la base de datos.
 
-También crea un módulo `Amigos.Repo` en `lib/amigos/repo.ex`
+También crea un módulo `Friends.Repo` en `lib/friends/repo.ex`
 
 ```elixir
-defmodule Amigos.Repo do
+defmodule Friends.Repo do
   use Ecto.Repo, 
-    otp_app: :amigos,
+    otp_app: :friends,
     adapter: Ecto.Adapters.Postgres
 end
 ```
 
-Usaremos el módulo `Amigos.Repo` para consultar la base de datos. También le decimos a este módulo que encuentre la configuración de su base de datos en la aplicación de Elixir `:amigos` y que elegimos el adaptador `Ecto.Adapters.Postgres`.
+Usaremos el módulo `Friends.Repo` para consultar la base de datos. También le decimos a este módulo que encuentre la configuración de su base de datos en la aplicación de Elixir `:friends` y que elegimos el adaptador `Ecto.Adapters.Postgres`.
 
-Después, configuraremos el módulo `Amigos.Repo` como supervisor dentro del árbol de supervisor de nuestra aplicación en `lib/amigos/application.ex`.
+Después, configuraremos el módulo `Friends.Repo` como supervisor dentro del árbol de supervisor de nuestra aplicación en `lib/friends/application.ex`.
 Esto iniciará el proceso de Ecto cuando nuestra aplicación inicie.
 
 ```elixir
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [
-      Amigos.Repo,
+      Friends.Repo,
     ]
 
   ...
@@ -101,7 +101,7 @@ Esto iniciará el proceso de Ecto cuando nuestra aplicación inicie.
 Después de eso tendremos que agregar la siguiente línea a `config/config.exs`:
 
 ```elixir
-config :amigos, ecto_repos: [Amigos.Repo]
+config :friends, ecto_repos: [Friends.Repo]
 ```
 
 Esto permitirá que nuestra aplicación pueda ejecutar comandos mix de ecto desde la terminal
@@ -123,19 +123,19 @@ Para crear y modificar tablas dentro de una base de datos postgres, Ecto nos pro
 Cada migración describe un grupo de acciones a ejecutar en nuestra base de datos, como que tablas crear o actualizar.
 
 Como nuestra base de datos no contiene aún ninguna tabla tendremos que crear una migración que agregue algunas.
-La convención en Ecto es pluralizar las tablas, así que para nuestra aplicación necesitaremos una tabla `personas`, así que empezemos por ahí.
+La convención en Ecto es pluralizar las tablas, así que para nuestra aplicación necesitaremos una tabla `people`, así que empezemos por ahí.
 
-La mejor forma de crear migraciones es con el comando mix `ecto.gen.migration <nombre>`, así que para nuestro caso ejecutaremos:
+La mejor forma de crear migraciones es con el comando mix `ecto.gen.migration <name>`, así que para nuestro caso ejecutaremos:
 
 ```shell
-$ mix ecto.gen.migration create_personas
+$ mix ecto.gen.migration create_people
 ```
 
 Esto generará un nuevo archivo en el directorio `priv/repo/migrations` que contendrá un timestamp en su nombre.
 Si navegamos a nuestro directorio y abrimos la migración veremos algo como esto:
 
 ```elixir
-defmodule Amigos.Repo.Migrations.CreatePeople do
+defmodule Friends.Repo.Migrations.CreatePeople do
   use Ecto.Migration
 
   def change do
@@ -144,16 +144,16 @@ defmodule Amigos.Repo.Migrations.CreatePeople do
 end
 ```
 
-Empezemos modificando la función `change/0` para crear una nueva tabla `personas` con `nombre` y `edad`:
+Empezemos modificando la función `change/0` para crear una nueva tabla `people` con `name` y `age`:
 
 ```elixir
-defmodule Amigos.Repo.Migrations.CreatePeople do
+defmodule Friends.Repo.Migrations.CreatePeople do
   use Ecto.Migration
 
   def change do
-    create table(:personas) do
+    create table(:people) do
       add :nombre, :string, null: false
-      add :edad, :integer, default: 0
+      add :age, :integer, default: 0
     end
   end
 end
@@ -173,58 +173,58 @@ $ mix ecto.migrate
 Ahora que creamos nuestra tabla inicial, tenemos que decirle a Ecto más sobre ella y parte de esto lo hacemos a través de esquemas.
 Un esquema es un módulo que define la relación con los campos de la base de datos.
 
-Mientras Ecto favorece pluralizar los nombres de las tablas de la base de datos, el esquema es usualmente singular, así que crearemos un esquema `Persona` para acompañar nuestra tabla.
+Mientras Ecto favorece pluralizar los nombres de las tablas de la base de datos, el esquema es usualmente singular, así que crearemos un esquema `Person` para acompañar nuestra tabla.
 
-Creemos nuestro nuevo esquema en `lib/amigos/person.ex`:
+Creemos nuestro nuevo esquema en `lib/friends/person.ex`:
 
 ```elixir
-defmodule Amigos.Persona do
+defmodule Friends.Person do
   use Ecto.Schema
 
-  schema "personas" do
-    field :nombre, :string
-    field :edad, :integer, default: 0
+  schema "people" do
+    field :name, :string
+    field :age, :integer, default: 0
   end
 end
 ```
 
-Aquí podemos ver que el módulo `Amigos.Persona` le dice a Ecto que el esquema se relaciona con la tabla `personas` y que tenemos dos columnas: `nombre` que es una cadena de texto y `edad`, que es un entero con un valor por default de `0`.
+Aquí podemos ver que el módulo `Friends.Person` le dice a Ecto que el esquema se relaciona con la tabla `people` y que tenemos dos columnas: `name` que es una cadena de texto y `age`, que es un entero con un valor por default de `0`.
 
 Echemos un vistazo a nuestro esquema abriendo `iex -S mix` y creando una nueva persona:
 
 ```shell
-iex> %Amigos.Persona{}
-%Amigos.Persona{edad: 0, nombre: nil}
+iex> %Friends.Person{}
+%Friends.Person{age: 0, name: nil}
 ```
 
-Como lo esperabamos, obtuvimos un nuevo `Persona` con el valor por defecto aplicado a `edad`.
+Como lo esperabamos, obtuvimos un nuevo `Person` con el valor por defecto aplicado a `age`.
 Ahora crearemos una persona "real":
 
 ```shell
-iex> person = %Amigos.Persona{nombre: "Tomás", edad: 11}
-%Amigos.Persona{edad: 11, nombre: "Tomás"}
+iex> person = %Friends.Person{name: "Tom", age: 11}
+%Friends.Person{age: 11, name: "Tom"}
 ```
 
 Como los esquemas son estructuras, podemos interactuar con nuestra data como estamos acostumbrados:
 
 ```elixir
-iex> person.nombre
-"Tomás"
-iex> Map.get(person, :nombre)
-"Tomás"
-iex> %{nombre: nombre} = person
-%Amigos.Persona{edad: 11, nombre: "Tomás"}
-iex> nombre
-"Tomás"
+iex> person.name
+"Tom"
+iex> Map.get(person, :name)
+"Tom"
+iex> %{name: name} = person
+%Friends.Person{age: 11, name: "Tom"}
+iex> name
+"Tom"
 ```
 
 Igualmente podemos actualizar nuestros esquemas justo como lo haríamos con cualquier otro mapa o estructura en Elixir:
 
 ```elixir
-iex> %{person | edad: 18}
-%Amigos.Persona{edad: 18, nombre: "Tomás"}
-iex> Map.put(person, :nombre, "Juan")
-%Amigos.Persona{edad: 11, nombre: "Juan"}
+iex> %{person | age: 18}
+%Friends.Person{age: 18, name: "Tom"}
+iex> Map.put(person, :name, "Jerry")
+%Friends.Person{age: 11, name: "Jerry"}
 ```
 
 En nuestra siguiente lección sobre Changesets, veremos como validar los cambios en nuestra data y finalmente como persistir estos en nuestra base de datos.

--- a/es/lessons/ecto/basics.md
+++ b/es/lessons/ecto/basics.md
@@ -1,351 +1,230 @@
 ---
-version: 0.9.1
+version: 2.4.0
 title: Basics
 ---
 
-Ecto es un proyecto oficial de Elixir, provee un envoltorio a la base de datos y un lenguaje de consultas integrado. Con Ecto podemos crear migraciones, definir modelos, insertar, actualizar y consultar registros de nuestra base de datos.
+Ecto es un proyecto oficial de Elixir que provee un envoltorio a la base de datos y un lenguaje de consultas integrado. Con Ecto podemos crear migraciones, definir modelos, insertar, actualizar y consultar registros de nuestra base de datos.
 
 {% include toc.html %}
 
-## Inicio
+### Adaptadores
 
-Para iniciar necesitamos incluir a Ecto y un adaptador a una base de datos en el fichero `mix.exs` de nuestro proyecto. Puede encontrar una lista de los adaptadores a bases de datos soportados en la sección [Usage](https://github.com/elixir-lang/ecto/blob/master/README.md#usage) del README de Ecto. Para nuestro ejemplo emplearemos PostgreSQL:
+Ecto soporta distintas bases de datos a través de adaptadores. Algunos ejemplos de estos son:
 
-```elixir
-defp deps do
-  [{:ecto, "~> 1.0"}, {:postgrex, ">= 0.0.0"}]
-end
-```
+* PostgreSQL
+* MySQL
+* SQLite
 
-Ahora podemos agregar Ecto y nuestro adaptador, `postgrex` en nuestro caso, a la lista de aplicaciones:
+Para esta lección configuraremos Ecto usando el adaptador para PostgreSQL.
 
-```elixir
-def application do
-  [applications: [:ecto, :postgrex]]
-end
-```
+### Inicio
 
-### Repositorio
+A través de esta lección cubriremos tres partes de Ecto:
 
-Finalmente necesitamos crear el repositorio de nuestro proyecto, el envoltorio a la base de datos. Esto puede realizarse al ejecutar la siguiente tarea Mix: `mix ecto.gen.repo -r ExampleApp.Repo`, describiremos las tareas Mix en subsiguientes secciones. El repositorio creado puede encontrarse en `lib/<nombre_proyecto>/repo.ex`
+* Repositorio - proveé la interfaz hacía nuestra base de datos, incluyendo la conexión
+* Migraciones - un mecanismo para crear, modificar y eliminar tablas e índices
+* Esquemas - estructuras especialidas que representan entradas en la base de datos
 
-```elixir
-defmodule ExampleApp.Repo do
-  use Ecto.Repo, otp_app: :example_app
-end
-```
-
-### Supervisor
-
-Una vez creado nuestro Repo necesitamos configurar nuestro árbol de supervisión, el cual usualmente se encuentra en `lib/<nombre_proyecto>.ex`.
-
-Es importante notar que configuramos Repo como un supervisor por medio de `supervisor/3` y _no_ por medio de `worker/3`. Si usted genera su aplicación con la opción `--sup` lo que viene a continuación seguramente ya existe:
-
-```elixir
-defmodule ExampleApp.App do
-  use Application
-
-  def start(_type, _args) do
-    import Supervisor.Spec
-
-    children = [
-      supervisor(ExampleApp.Repo, [])
-    ]
-
-    opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-end
-```
-
-<!-- TODO: Remove this as a comment, once advanced/otp-supervisors  is translated to Spanish
-Para mayor información acerca de supervisores revisa la lección [Supervisores OTP](../../advanced/otp-supervisors).
--->
-
-### Configuración
-
-Para configurar Ecto necesitamos agregar una sección a nuestro `config/config.exs`. Acá especificaremos el repositorio, adaptador, base de datos e información de acceso:
-
-```elixir
-config :example_app, ExampleApp.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  database: "example_app",
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost"
-```
-
-## Tareas Mix
-
-Ecto incluye cierto número de tareas Mix útiles para trabajar con nuestra base de datos:
+Para empezar crearemos una aplicación con su árbol de supervisión.
 
 ```shell
-mix ecto.create         # Crea el almacenamiento de nuestro repositorio
-mix ecto.drop           # Elimina el almacenamiento para nuestro repositorio
-mix ecto.gen.migration  # Genera una nueva migración para nuestro repositorio
-mix ecto.gen.repo       # Genera un nuevo repositorio
-mix ecto.migrate        # Ejecuta migraciones sobre nuestro repositorio
-mix ecto.rollback       # Revierte las migraciones aplicadas a nuestro repositorio
+$ mix new amigos --sup
+$ cd amigos
 ```
+
+Agrega los paquetes de ecto y postgrex a tu archivo `mix.exs`
+
+```elixir
+  defp deps do
+    [
+      {:ecto_sql, "~> 3.2"},
+      {:postgrex, "~> 0.15"}
+    ]
+  end
+```
+
+Y descarga las dependencias ejecutando
+
+```shell
+$ mix deps.get
+```
+
+#### Creando un repositorio
+
+Un repositorio en Ecto se relaciona con un set de datos, como nuestra base de datos PostgreSQL.
+Toda comunicación con la base de datos se hará usando este repositorio.
+
+Configura un repositorio ejecutando:
+
+```shell
+$ mix ecto.gen.repo -r Amigos.Repo
+```
+
+Esto generará la configuración requerida en `config/config.exs` para conectarse a la base de datos, incluyendo el adaptador que usará.
+Este es el archivo de configuración de nuestra aplicación `Amigos`
+
+```elixir
+config :amigos, Amigos.Repo,
+  database: "amigos_repo",
+  usernombre: "postgres",
+  password: "",
+  hostnombre: "localhost"
+```
+
+Esto configura como Ecto se conectará a la base de datos.
+
+También crea un módulo `Amigos.Repo` en `lib/amigos/repo.ex`
+
+```elixir
+defmodule Amigos.Repo do
+  use Ecto.Repo, 
+    otp_app: :amigos,
+    adapter: Ecto.Adapters.Postgres
+end
+```
+
+Usaremos el módulo `Amigos.Repo` para consultar la base de datos. También le decimos a este módulo que encuentre la configuración de su base de datos en la aplicación de Elixir `:amigos` y que elegimos el adaptador `Ecto.Adapters.Postgres`.
+
+Después, configuraremos el módulo `Amigos.Repo` como supervisor dentro del árbol de supervisor de nuestra aplicación en `lib/amigos/application.ex`.
+Esto iniciará el proceso de Ecto cuando nuestra aplicación inicie.
+
+```elixir
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      Amigos.Repo,
+    ]
+
+  ...
+```
+
+Después de eso tendremos que agregar la siguiente línea a `config/config.exs`:
+
+```elixir
+config :amigos, ecto_repos: [Amigos.Repo]
+```
+
+Esto permitirá que nuestra aplicación pueda ejecutar comandos mix de ecto desde la terminal
+
+Hemos terminado con la configuración de nuestro repositorio!
+Ahora podemos crear la base de datos dentro de postgres con este comando:
+
+```shell
+$ mix ecto.create
+```
+
+Ecto usará la información en `config/config.exs` para determinar como conectarse con Postgres y que nombre darle a la base de datos.
+
+Si recibes algún error verifica que la configuración es la correcta y que tu instancia de postgres está corriendo.
 
 ## Migraciones
 
-La mejor manera de crear migraciones es a través de `mix ecto.gen.migration <nombre>`. Si usted está familiarizado con ActiveRecord esto le parecerá familiar.
+Para crear y modificar tablas dentro de una base de datos postgres, Ecto nos proveé con migraciones.
+Cada migración describe un grupo de acciones a ejecutar en nuestra base de datos, como que tablas crear o actualizar.
 
-Comencemos por ver el detalle de la migración para la tabla de usuarios:
+Como nuestra base de datos no contiene aún ninguna tabla tendremos que crear una migración que agregue algunas.
+La convención en Ecto es pluralizar las tablas, así que para nuestra aplicación necesitaremos una tabla `personas`, así que empezemos por ahí.
+
+La mejor forma de crear migraciones es con el comando mix `ecto.gen.migration <nombre>`, así que para nuestro caso ejecutaremos:
+
+```shell
+$ mix ecto.gen.migration create_personas
+```
+
+Esto generará un nuevo archivo en el directorio `priv/repo/migrations` que contendrá un timestamp en su nombre.
+Si navegamos a nuestro directorio y abrimos la migración veremos algo como esto:
 
 ```elixir
-defmodule ExampleApp.Repo.Migrations.CreateUser do
+defmodule Amigos.Repo.Migrations.CreatePeople do
   use Ecto.Migration
 
   def change do
-    create table(:users) do
-      add(:username, :string, unique: true)
-      add(:encrypted_password, :string, null: false)
-      add(:email, :string)
-      add(:confirmed, :boolean, default: false)
 
-      timestamps
-    end
-
-    create(unique_index(:users, [:username], name: :unique_usernames))
   end
 end
 ```
 
-Por omisión Ecto crea un `id` auto incremental como llave primaria. Acá estamos usando el _callback_ por omisión `change/0` pero Ecto también soporta `up/0` y `down/0` por si usted requiere un control más granular.
-
-Como usted seguramente ya habrá descubierto al agregar `timestamps` a su migración Ecto creará y manejará los campos `inserted_at` y `updated_at` por usted.
-
-Para aplicar nuestra nueva migración ejecute el comando `mix ecto.migrate`
-
-Para mayor detalle acerca de las migraciones vea la sección [Ecto.Migration](http://hexdocs.pm/ecto/Ecto.Migration.html#content) de la documentación oficial.
-
-## Modelos
-
-Ahora que tenemos nuestra migración podemos movernos a nuestro modelo. Los modelos definen nuestro esquema, funciones auxiliares y nuestro _set de cambios_, cubriremos más acerca del _set de cambios_ en secciones subsiguientes.
-
-Por ahora veamos como luce el modelo para nuestra migración:
+Empezemos modificando la función `change/0` para crear una nueva tabla `personas` con `nombre` y `edad`:
 
 ```elixir
-defmodule ExampleApp.User do
-  use Ecto.Schema
-  import Ecto.Changeset
+defmodule Amigos.Repo.Migrations.CreatePeople do
+  use Ecto.Migration
 
-  schema "users" do
-    field(:username, :string)
-    field(:encrypted_password, :string)
-    field(:email, :string)
-    field(:confirmed, :boolean, default: false)
-    field(:password, :string, virtual: true)
-    field(:password_confirmation, :string, virtual: true)
-
-    timestamps
-  end
-
-  @required_fields ~w(username encrypted_password email)
-  @optional_fields ~w()
-
-  def changeset(user, params \\ :empty) do
-    user
-    |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:username)
-  end
-end
-```
-
-El esquema que hemos definido en nuestro modelo es muy similar a lo que especificamos en nuestra migración. Además de los campos de nuestra base de datos también hemos incluido 2 campos virtuales. Los campos virtuales no son almacenados en la base de datos pero pueden ser útiles para cuestiones como validaciones. Veremos en acción los campos virtuales en la sección que hace referencia a los [set de cambios](#set_de_cambios)
-
-## Consultas
-
-Antes de realizar consultas a nuestro repositorio necesitamos importar el API Query, por ahora solo necesitamos importar `from/2`:
-
-```elixir
-import Ecto.Query, only: [from: 2]
-```
-
-Para mayor detalle puede consultar la documentación oficial de [Ecto.Query](http://hexdocs.pm/ecto/Ecto.Query.html).
-
-### Básico
-
-Ecto provee un excelente lenguaje específico de dominio (DSL, por sus siglas en inglés) para expresar consultas de manera clara. Para buscar los nombres de usuario con sus cuentas confirmadas podemos usar algo como:
-
-```elixir
-alias ExampleApp.{Repo, User}
-
-query =
-  from(
-    u in User,
-    where: u.confirmed == true,
-    select: u.username
-  )
-
-Repo.all(query)
-```
-
-Además de `all/2`, Repo provee cierto número de _callbacks_ que incluyen `one/2`, `get/3`, `insert/2` y `delete/2`. La lista completa de _callbacks_ puede ser encontrada en [Ecto.Repo#callbacks](http://hexdocs.pm/ecto/Ecto.Repo.html#callbacks).
-
-### Count
-
-```elixir
-query =
-  from(
-    u in User,
-    where: u.confirmed == true,
-    select: count(u.id)
-  )
-```
-
-### Group By
-
-Para agrupar el número de nombres de usuarios en base a su estado de confirmación de cuenta podemos incluir la opción `group_by`:
-
-```elixir
-query =
-  from(
-    u in User,
-    group_by: u.confirmed,
-    select: [u.confirmed, count(u.id)]
-  )
-
-Repo.all(query)
-```
-
-### Order By
-
-Ordenando los usuarios en base a su fecha de inserción:
-
-```elixir
-query =
-  from(
-    u in User,
-    order_by: u.inserted_at,
-    select: [u.username, u.inserted_at]
-  )
-
-Repo.all(query)
-```
-
-Para ordenar de manera decreciente usamos `DESC`:
-
-```elixir
-query =
-  from(
-    u in User,
-    order_by: [desc: u.inserted_at],
-    select: [u.username, u.inserted_at]
-  )
-```
-
-### Joins
-
-Asumiendo que tenemos un perfil asociado a nuestro usuario, busquemos todos los perfiles de cuentas confirmadas:
-
-```elixir
-query =
-  from(
-    p in Profile,
-    join: u in assoc(p, :user),
-    where: u.confirmed == true
-  )
-```
-
-### Fragmentos
-
-En algunas ocasiones el API que ofrece `Ecto.Query` no es suficiente, por ejemplo, cuando necesitamos funciones específicas de la base de datos. La función `fragment/1` existe para cubrir estos casos:
-
-```elixir
-query =
-  from(
-    u in User,
-    where: fragment("downcase(?)", u.username) == ^username,
-    select: u
-  )
-```
-
-Ejemplos adicionales sobre el uso del API Ecto.Query pueden encontrarse en [phoenix-examples/ecto_query_library](https://github.com/phoenix-examples/ecto_query_library).
-
-## Set de cambios
-
-En la sección previa aprendimos como obtener datos, pero no realizar inserciones o actualizaciones de los mismos, para ello necesitamos los _set de cambios_.
-
-Los _set de cambios_ se encargan de filtrar, validar y respetar las restricciones cuando el modelo cambia.
-
-Para este ejemplo nos enfocaremos en el _set de cambios_ para la creación de la cuenta de usuario. Para comenzar necesitamos actualizar nuestro modelo:
-
-```elixir
-defmodule ExampleApp.User do
-  use Ecto.Schema
-  import Ecto.Changeset
-  import Comeonin.Bcrypt, only: [hashpwsalt: 1]
-
-  schema "users" do
-    field(:username, :string)
-    field(:encrypted_password, :string)
-    field(:email, :string)
-    field(:confirmed, :boolean, default: false)
-    field(:password, :string, virtual: true)
-    field(:password_confirmation, :string, virtual: true)
-
-    timestamps
-  end
-
-  @required_fields ~w(username email password password_confirmation)
-  @optional_fields ~w()
-
-  def changeset(user, params \\ :empty) do
-    user
-    |> cast(params, @required_fields, @optional_fields)
-    |> validate_length(:password, min: 8)
-    |> validate_password_confirmation()
-    |> unique_constraint(:username, name: :email)
-    |> put_change(:encrypted_password, hashpwsalt(params[:password]))
-  end
-
-  defp validate_password_confirmation(changeset) do
-    case get_change(changeset, :password_confirmation) do
-      nil ->
-        password_incorrect_error(changeset)
-
-      confirmation ->
-        password = get_field(changeset, :password)
-        if confirmation == password, do: changeset, else: password_mismatch_error(changeset)
+  def change do
+    create table(:personas) do
+      add :nombre, :string, null: false
+      add :edad, :integer, default: 0
     end
   end
-
-  defp password_mismatch_error(changeset) do
-    add_error(changeset, :password_confirmation, "Passwords does not match")
-  end
-
-  defp password_incorrect_error(changeset) do
-    add_error(changeset, :password, "is not valid")
-  end
 end
 ```
 
-Hemos mejorado nuestra funcion `changeset/2` y hemos incluido tres funciones auxiliares: `validate_password_confirmation/1`, `password_mismatch_error/1` y `password_incorrect_error/1`.
+Puedes ver que hemos definido el tipo de dato de las columnas.
+Adicionalmente hemos incluido `null: false` y `default: 0` como opciones.
 
-Como su nombre sugiere `changeset/2` crea un nuevo _set de cambios_ por nosotros. Dentro de el se usa `cast/4` para convertir nuestros parámetros a un _set de cambios_ a partir de un conjunto de campos requeridos y opcionales. Seguidamente validamos la longitud de la contraseña, confirmamos la contraseña con una función privada y se verifica que el nombre de usuario proporcionado sea único. Finalmente actualizamos el campo de la base de datos que contiene la contraseña, para actualizar el valor en el _set de cambios_ usamos `put_change/3`.
+Movámonos a la terminal y ejecutemos nuestra migración:
 
-El uso de `User.changeset/2` es relativamente sencillo:
+```shell
+$ mix ecto.migrate
+```
+
+## Esquemas
+
+Ahora que creamos nuestra tabla inicial, tenemos que decirle a Ecto más sobre ella y parte de esto lo hacemos a través de esquemas.
+Un esquema es un módulo que define la relación con los campos de la base de datos.
+
+Mientras Ecto favorece pluralizar los nombres de las tablas de la base de datos, el esquema es usualmente singular, así que crearemos un esquema `Persona` para acompañar nuestra tabla.
+
+Creemos nuestro nuevo esquema en `lib/amigos/person.ex`:
 
 ```elixir
-alias ExampleApp.{User, Repo}
+defmodule Amigos.Persona do
+  use Ecto.Schema
 
-pw = "passwords should be hard"
-
-changeset =
-  User.changeset(%User{}, %{
-    username: "doomspork",
-    email: "sean@seancallan.com",
-    password: pw,
-    password_confirmation: pw
-  })
-
-case Repo.insert(changeset) do
-  {:ok, model}        -> # Inserted with success
-  {:error, changeset} -> # Something went wrong
+  schema "personas" do
+    field :nombre, :string
+    field :edad, :integer, default: 0
+  end
 end
 ```
 
-Esto es todo! Ahora usted está listo para almacenar sus datos.
+Aquí podemos ver que el módulo `Amigos.Persona` le dice a Ecto que el esquema se relaciona con la tabla `personas` y que tenemos dos columnas: `nombre` que es una cadena de texto y `edad`, que es un entero con un valor por default de `0`.
+
+Echemos un vistazo a nuestro esquema abriendo `iex -S mix` y creando una nueva persona:
+
+```shell
+iex> %Amigos.Persona{}
+%Amigos.Persona{edad: 0, nombre: nil}
+```
+
+Como lo esperabamos, obtuvimos un nuevo `Persona` con el valor por defecto aplicado a `edad`.
+Ahora crearemos una persona "real":
+
+```shell
+iex> person = %Amigos.Persona{nombre: "Tomás", edad: 11}
+%Amigos.Persona{edad: 11, nombre: "Tomás"}
+```
+
+Como los esquemas son estructuras, podemos interactuar con nuestra data como estamos acostumbrados:
+
+```elixir
+iex> person.nombre
+"Tomás"
+iex> Map.get(person, :nombre)
+"Tomás"
+iex> %{nombre: nombre} = person
+%Amigos.Persona{edad: 11, nombre: "Tomás"}
+iex> nombre
+"Tomás"
+```
+
+Igualmente podemos actualizar nuestros esquemas justo como lo haríamos con cualquier otro mapa o estructura en Elixir:
+
+```elixir
+iex> %{person | edad: 18}
+%Amigos.Persona{edad: 18, nombre: "Tomás"}
+iex> Map.put(person, :nombre, "Juan")
+%Amigos.Persona{edad: 11, nombre: "Juan"}
+```
+
+En nuestra siguiente lección sobre Changesets, veremos como validar los cambios en nuestra data y finalmente como persistir estos en nuestra base de datos.


### PR DESCRIPTION
- Updates the Ecto/Basics ES lesson to 2.4.0
- Fixes bad spelling of `accompany` in the [EN] Ecto/Basics lesson

Closes #2090 