### PR TITLE
Add a small reference to the pipe operator

### DIFF
--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -101,6 +101,7 @@ false
 ```
 
 The booleans `true` and `false` are also the atoms `:true` and `:false`, respectively.
+*The pipe operator |> passes the result of an expression as the first parameter of another expression. We will explore this more in-depth in chapter 7: "Pipe Operator"*
 
 ```elixir
 iex> true |> is_atom

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -101,12 +101,11 @@ false
 ```
 
 The booleans `true` and `false` are also the atoms `:true` and `:false`, respectively.
-*The pipe operator |> passes the result of an expression as the first parameter of another expression. We will explore this more in-depth in chapter 7: "Pipe Operator"*
 
 ```elixir
-iex> true |> is_atom
+iex> is_atom(true)
 true
-iex> :true |> is_boolean
+iex> is_boolean(:true)
 true
 iex> :true === true
 true


### PR DESCRIPTION
One thing that really bothered me throughout learning is that the pipe operator wasn't mentioned during the first few chapters in the basics. Therefore I propose a change in order to make the lives of newcomers easier. This change introduces a reference to the pipe operator which should be enough to get newcomers to understand what's going on.