### PR TITLE
[EN] lessons/ecto/querying Rework part about keyword and query expressions

### DIFF
--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.4
+version: 1.1.0
 title: Querying
 ---
 
@@ -164,9 +164,7 @@ SELECT m0."title" FROM "movies" AS m0 []
 The good thing about macros is that they work very well with pipes:
 
 ```elixir
-query = Movie
-|> where([m], m.id < 2)
-|> select([m], {m.title})
+iex> query = Movie |> where([m], m.id < 2) |> select([m], {m.title})
 
 iex> Repo.all(query)
 [{"Ready Player One"}]

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -122,7 +122,7 @@ Queries like this are called *bindingless*, because they are simple enough to no
 So far we used a module that implements the `Ecto.Queryable` protocol (ex: `Movie`) as the first argument for `from` macro. However, we can also use `in` expression, like this:
 
 ```elixir
-query = from(m in Movie)                                                           
+iex> query = from(m in Movie)                                                           
 %Ecto.Query<from m in Example.Movie>
 ```
 

--- a/en/lessons/ecto/querying.md
+++ b/en/lessons/ecto/querying.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.3
+version: 1.0.4
 title: Querying
 ---
 
@@ -61,14 +61,14 @@ If we want to write more complex queries, or if we want to return _all_ records 
 
 The `Ecto.Query` module provides us with the Query DSL which we can use to write queries to retrieve data from the application's repository.
 
-### Creating Queries with `Ecto.Query.from/2`
+### Keyword-based queries with `Ecto.Query.from/2`
 
-We can create a query with the `Ecto.Query.from/2` function. This function takes in two arguments: an expression and a keyword list. Let's create a query to select all of the movies from our repository:
+We can create a query with the `Ecto.Query.from/2` macro. This function takes in two arguments: an expression and an optional keyword list. Let's create the most simple query to select all of the movies from our repository:
 
 ```elixir
 import Ecto.Query
-query = from(m in Movie, select: m)
-#Ecto.Query<from m in Example.Movie, select: m>
+query = from(Movie)                
+%Ecto.Query<from m in Example.Movie>
 ```
 
 In order to execute our query, we use the `Repo.all/2` function. This function takes in a required argument of an Ecto query and returns all of the records that meet the conditions of the query.
@@ -90,113 +90,88 @@ iex> Repo.all(query)
 ]
 ```
 
-#### Using `from` with Keyword Queries
+#### Bindingless queries with `from`
 
-The example above gives the `from/2` an argument of a *keyword query*. When using `from` with a keyword query, the first argument can be one of two things:
-
-* An `in` expression (ex: `m in Movie`)
-* A module that implements the `Ecto.Queryable` protocol (ex: `Movie`)
-
-The second argument is our `select` keyword query.
-
-#### Using `from` with a Query Expression
-
-When using `from` with a query expression, the first argument must be a value that implements the `Ecto.Queryable` protocol (ex: `Movie`). The second argument is an expression. Let's take a look at an example:
+The example above lacks the most fun parts of SQL statements. We often want to only query for specific fields or filter records by some condition. Let's fetch `title` and `tagline` of all movies that have `"Ready Player One"` title:
 
 ```elixir
-iex> query = select(Movie, [m], m)
-%Ecto.Query<from m in Example.Movie, select: m>
-iex> Repo.all(query)
+iex> query = from(Movie, where: [title: "Ready Player One"], select: [:title, :tagline])
+%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One",
+ select: [:title, :tagline]>
 
-06:16:20.854 [debug] QUERY OK source="movies" db=0.9ms
+iex> Repo.all(query)                                                                    
+SELECT m0."title", m0."tagline" FROM "movies" AS m0 WHERE (m0."title" = 'Ready Player One') []
 [
   %Example.Movie{
-    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
-    id: 1,
+    __meta__: #Ecto.Schema.Metadata<:loaded, "movies">,
+    actors: #Ecto.Association.NotLoaded<association :actors is not loaded>,
+    characters: #Ecto.Association.NotLoaded<association :characters is not loaded>,
+    id: nil,
     tagline: "Something about video games",
     title: "Ready Player One"
   }
 ]
 ```
 
-You can use query expressions when you _don't_ need an `in` statement (`m in Movie`). You don't need an `in` statement when you don't need a reference to the data structure. Our query above doesn't require a reference to the data structure--we're not, for example, selecting movies where a given condition is met. So there's no need to use `in` expressions and keyword queries.
+Please note that the returned struct only has `tagline` and `title` fields set – this is the result of our `select:` part.
 
-### Using `select` expressions
+Queries like this are called *bindingless*, because they are simple enough to not require bindings.
 
-We use the `Ecto.Query.select/3` function to specify the select statement portion of our query. If we want to select only certain fields, we can specify those fields as a list of atoms or by referencing the struct's keys. Let's take a look at the first approach:
+#### Bindings in queries
+
+So far we used a module that implements the `Ecto.Queryable` protocol (ex: `Movie`) as the first argument for `from` macro. However, we can also use `in` expression, like this:
 
 ```elixir
-iex> query = select(Movie, [:title])
-%Ecto.Query<from m in Example.Movie, select: [:title]>
-iex> Repo.all(query)
-
-15:15:25.842 [debug] QUERY OK source="movies" db=1.3ms
-[
-  %Example.Movie{
-    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
-    id: nil,
-    tagline: nil,
-    title: "Ready Player One"
-  }
-]
+query = from(m in Movie)                                                           
+%Ecto.Query<from m in Example.Movie>
 ```
 
-Notice that we did _not_ use an `in` expression for the first argument given to our `from` function. That is because we did not need to create a reference to our data structure in order to use a keyword list with `select`.
-
-This approach returns a struct with only the specified field, `title`, populated.
-
-The second approach behaves a little differently. This time, we *do* need to use an `in` expression. This is because we need to create a reference to our data structure in order to specify the `title` key of the movie struct:
+In such case, we call `m` a *binding*. Bindings are extremely useful, because they allow us to reference modules in other parts of the query. Let's select titles of all movies that have `id` less than `2`:
 
 ```elixir
-iex(15)> query = from(m in Movie, select: m.title)
-%Ecto.Query<from m in Example.Movie, select: m.title>
-iex(16)> Repo.all(query)
+iex> query = from(m in Movie, where: m.id < 2, select: m.title)
+#Ecto.Query<from m in Example.Movie, where: m.id < 2, select: m.title>
 
-15:06:12.752 [debug] QUERY OK source="movies" db=4.5ms queue=0.1ms
+iex> Repo.all(query)                                           
+SELECT m0."title" FROM "movies" AS m0 WHERE (m0."id" < 2) []
 ["Ready Player One"]
 ```
 
-Notice that this approach to using `select` returns a list containing the selected values.
-
-### Using `where` expressions
-
-We can use `where` expressions to include "where" clauses in our queries. Multiple `where` expressions are combined into `WHERE AND` SQL statements.
+The very important thing here is how output of the query changed. Using an *expression* with a binding in `select:` part allows you to specify exactly the way selected fields will be returned. We can ask for a tuple, for example:
 
 ```elixir
-iex> query = from(m in Movie, where: m.title == "Ready Player One")
-%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One">
-iex> Repo.all(query)
+iex> query = from(m in Movie, where: m.id < 2, select: {m.title})             
 
-15:18:35.355 [debug] QUERY OK source="movies" db=4.1ms queue=0.1ms
-[
-  %Example.Movie{
-    __meta__: %Ecto.Schema.Metadata<:loaded, "movies">,
-    actors: %Ecto.Association.NotLoaded<association :actors is not loaded>,
-    characters: %Ecto.Association.NotLoaded<association :characters is not loaded>,
-    distributor: %Ecto.Association.NotLoaded<association :distributor is not loaded>,
-    id: 1,
-    tagline: "Something about video games",
-    title: "Ready Player One"
-  }
-]
+iex> Repo.all(query)                                                          
+[{"Ready Player One"}]
 ```
 
-We can use `where` expressions together with `select`:
+It is a good idea to always start with a simple bindingless query and introduce a binding whenever you need to reference your data structure. More on bindings in queries can be found in [Ecto documentation](https://hexdocs.pm/ecto/Ecto.Query.html#module-query-expressions)
+
+
+### Macro-based queries
+
+In the examples above we used keywords `select:` and `where:` inside of `from` macro to build a query – these are so called *keyword-based queries*. There is, however, another way to compose queries – macro-based queries. Ecto provides macros for every keyword, like `select/3` or `where/3`. Each macro accepts a *queryable* value, *an explicit list of bindings* and the same expression you'd provide to its keyword analogue:
 
 ```elixir
-iex> query = from(m in Movie, where: m.title == "Ready Player One", select: m.tagline)
-%Ecto.Query<from m in Example.Movie, where: m.title == "Ready Player One", select: m.tagline>
-iex> Repo.all(query)
-
-15:19:11.904 [debug] QUERY OK source="movies" db=4.1ms
-["Something about video games"]
+iex> query = select(Movie, [m], m.title)                           
+%Ecto.Query<from m in Example.Movie, select: m.title>
+iex> Repo.all(query)                    
+SELECT m0."title" FROM "movies" AS m0 []
+["Ready Player One"]
 ```
+
+The good thing about macros is that they work very well with pipes:
+
+```elixir
+query = Movie
+|> where([m], m.id < 2)
+|> select([m], {m.title})
+
+iex> Repo.all(query)
+[{"Ready Player One"}]
+```
+
 
 ### Using `where` with Interpolated Values
 


### PR DESCRIPTION
Hello!

I've been translation ecto querying lesson and was confused by `from` and `select` part. It looks like keyword-based and macro-based queries subject somehow got mixed with bindingless and bindingful expressions. So I decided to make a step back and rework this part of the lesson to be more aligned with ecto documentation.

I am by no means proficient in English so please feel free to comment on grammar and wording or even take this PR over for further work.