### PR TITLE
Updating .typo-ci.yml to use strings for excluded files

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -9,33 +9,33 @@ dictionaries:
   - it
 
 excluded_files:
-  - *.yml
-  - .github/**/*
-  - _assets/**/*
-  - _includes/**/*
-  - _layouts/**/*
-  - _plugins/**/*
-  - script/**/*
-  - ar/**/*
-  - bg/**/*
-  - bn/**/*
-  - gr/**/*
-  - id/**/*
-  - ja/**/*
-  - ko/**/*
-  - ms/**/*
-  - no/**/*
-  - pl/**/*
-  - pt/**/*
-  - ru/**/*
-  - sk/**/*
-  - ta/**/*
-  - th/**/*
-  - tr/**/*
-  - uk/**/*
-  - vi/**/*
-  - zh-hans/**/*
-  - zh-hant/**/*
+  - "*.yml"
+  - ".github/**/*"
+  - "_assets/**/*"
+  - "_includes/**/*"
+  - "_layouts/**/*"
+  - "_plugins/**/*"
+  - "script/**/*"
+  - "ar/**/*"
+  - "bg/**/*"
+  - "bn/**/*"
+  - "gr/**/*"
+  - "id/**/*"
+  - "ja/**/*"
+  - "ko/**/*"
+  - "ms/**/*"
+  - "no/**/*"
+  - "pl/**/*"
+  - "pt/**/*"
+  - "ru/**/*"
+  - "sk/**/*"
+  - "ta/**/*"
+  - "th/**/*"
+  - "tr/**/*"
+  - "uk/**/*"
+  - "vi/**/*"
+  - "zh-hans/**/*"
+  - "zh-hant/**/*"
 
 excluded_words:
   - defp


### PR DESCRIPTION
Just following up on https://github.com/elixirschool/elixirschool/pull/2134#discussion_r347145976 

I ran the current `.typo-ci.yml` through a linter ( http://www.yamllint.com/ ) and it raised a validation error (starting a string with `*` was the issue),  converting the paths to strings fixes this.

Typo CI wise, this meant it would ignore the `yml` file as it was unable to parse it (Which I think silently failing isn't ideal). I'm going to update it on my end to make an invalid `.typo-ci.yml` more clear.