### PR TITLE
Add missing commas in otp-supervisors.md

### DIFF
--- a/de/lessons/advanced/otp-supervisors.md
+++ b/de/lessons/advanced/otp-supervisors.md
@@ -71,9 +71,9 @@ Die Macros `use GenServer`, `use Supervisor`, und `use Agent` definieren diese M
 def child_spec(opts) do
   %{
     id: SimpleQueue,
-    start: {__MODULE__, :start_link, [opts]}
-    shutdown: 5_000
-    restart: :permanent
+    start: {__MODULE__, :start_link, [opts]},
+    shutdown: 5_000,
+    restart: :permanent,
     type: :worker
   }
 end
@@ -91,7 +91,7 @@ Die Optionen sind:
 
   + `:brutal_kill` - Kind wird sofort gestoppt
 
-  + ein positiver Integer - Zeit in Millisekunden, die der Supervisor warten wird, bevor er den Kind-Prozess killt. 
+  + ein positiver Integer - Zeit in Millisekunden, die der Supervisor warten wird, bevor er den Kind-Prozess killt.
   Wenn der Prozess vom Typ `:worker` ist, ist dieser Wert standardmäßig 5000.
 
   + `:infinity` - Der Supervisor wird unednlich lange warten, bevor er den Prozess killt.

--- a/es/lessons/advanced/otp-supervisors.md
+++ b/es/lessons/advanced/otp-supervisors.md
@@ -76,9 +76,9 @@ Después de que el supervisor ha comenzado este debe saber como comenzar/parar/r
 def child_spec(opts) do
   %{
     id: SimpleQueue,
-    start: {__MODULE__, :start_link, [opts]}
-    shutdown: 5_000
-    restart: :permanent
+    start: {__MODULE__, :start_link, [opts]},
+    shutdown: 5_000,
+    restart: :permanent,
     type: :worker
   }
 end

--- a/ja/lessons/advanced/otp-supervisors.md
+++ b/ja/lessons/advanced/otp-supervisors.md
@@ -81,9 +81,9 @@ iex> SimpleQueue.queue
 def child_spec(opts) do
   %{
     id: SimpleQueue,
-    start: {__MODULE__, :start_link, [opts]}
-    shutdown: 5_000
-    restart: :permanent
+    start: {__MODULE__, :start_link, [opts]},
+    shutdown: 5_000,
+    restart: :permanent,
     type: :worker
   }
 end

--- a/pt/lessons/advanced/otp-supervisors.md
+++ b/pt/lessons/advanced/otp-supervisors.md
@@ -76,9 +76,9 @@ Depois que o supervisor iniciou, ele deve saber como iniciar/parar/reiniciar seu
 def child_spec(opts) do
   %{
     id: SimpleQueue,
-    start: {__MODULE__, :start_link, [opts]}
-    shutdown: 5_000
-    restart: :permanent
+    start: {__MODULE__, :start_link, [opts]},
+    shutdown: 5_000,
+    restart: :permanent,
     type: :worker
   }
 end

--- a/zh-hant/lessons/advanced/otp-supervisors.md
+++ b/zh-hant/lessons/advanced/otp-supervisors.md
@@ -49,7 +49,7 @@ defmodule SimpleQueue.Application do
 end
 ```
 
-如果執行 `iex -S mix` 將會看到 `SimpleQueue` 被自動地啟動。 
+如果執行 `iex -S mix` 將會看到 `SimpleQueue` 被自動地啟動。
 
 ```elixir
 iex> SimpleQueue.queue
@@ -76,9 +76,9 @@ Supervisors 目前有三種不同的重新啟動策略：
 def child_spec(opts) do
   %{
     id: SimpleQueue,
-    start: {__MODULE__, :start_link, [opts]}
-    shutdown: 5_000
-    restart: :permanent
+    start: {__MODULE__, :start_link, [opts]},
+    shutdown: 5_000,
+    restart: :permanent,
     type: :worker
   }
 end


### PR DESCRIPTION
This commit adds commas to the maps returned by `child_spec/1` in the
OTP Supervisors lesson. A previous PR fixed this for the english
version. This commit fixes the issue for the following versions:
* de
* es
* ja
* pt
* zh-hant

Previous PR: #2188