### PR TITLE
Add translation report reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To run locally, you need both Ruby and Bundler installed.
 
 1. Each of the languages has a folder in root of this repo. To start translating you need to copy a file from the English language to the corresponding folder in your language and start translating.
 
-2. Translated lessons must include page metadata.
+2. Check the [translation report](https://elixirschool.com/pt/report/) for pages that haven't been translated yet, or for pages which need to have their translations updated in the corresponding language you want to work with.
+
+3. Translated lessons must include page metadata.
    * `title` should be a translation of the original lesson's `title`.
    * `version` should be set to the original English `version`.
 
@@ -41,7 +43,5 @@ To run locally, you need both Ruby and Bundler installed.
   version: 1.0.0
   ---
   ```
-  
-3. Send a PR with the new translated lesson and join [https://elixirschool.com/contributors/](_data/contributors.yml).
 
-
+4. Send a PR with the new translated lesson and join [https://elixirschool.com/contributors/](_data/contributors.yml).


### PR DESCRIPTION
The [translation report (example for Portuguese)](https://https://elixirschool.com/pt/report/) lists the pages that need to have their content updated or that need to be translated from scratch.

Having the address for the report inside the README.md file along with the other translation instructions makes it easier for people new to the project to pick up a page and translate it, or update the contents of a translation in a given language. What do you think? :)

## Some questions
- [ ] Is there any more information we should add in the README file regarding the translation report?
- [ ] Are there any extra steps involving the translation report that people should do before their translation is able to be merged?

This is my first contribution to the project, thanks in advance! 😄 