### PR TITLE
Updates to reflect current behaviour of `mix new`

### DIFF
--- a/en/lessons/advanced/umbrella-projects.md
+++ b/en/lessons/advanced/umbrella-projects.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.0.3
 title: Umbrella Projects
 ---
 
@@ -53,8 +53,6 @@ $ mix new utilities
 * creating README.md
 * creating .gitignore
 * creating mix.exs
-* creating config
-* creating config/config.exs
 * creating lib
 * creating lib/utilities.ex
 * creating test
@@ -75,8 +73,6 @@ $ mix new datasets
 * creating README.md
 * creating .gitignore
 * creating mix.exs
-* creating config
-* creating config/config.exs
 * creating lib
 * creating lib/datasets.ex
 * creating test
@@ -96,8 +92,6 @@ $ mix new svm
 * creating README.md
 * creating .gitignore
 * creating mix.exs
-* creating config
-* creating config/config.exs
 * creating lib
 * creating lib/svm.ex
 * creating test
@@ -122,8 +116,6 @@ $ tree
 ├── apps
 │   ├── datasets
 │   │   ├── README.md
-│   │   ├── config
-│   │   │   └── config.exs
 │   │   ├── lib
 │   │   │   └── datasets.ex
 │   │   ├── mix.exs
@@ -132,8 +124,6 @@ $ tree
 │   │       └── test_helper.exs
 │   ├── svm
 │   │   ├── README.md
-│   │   ├── config
-│   │   │   └── config.exs
 │   │   ├── lib
 │   │   │   └── svm.ex
 │   │   ├── mix.exs
@@ -142,8 +132,6 @@ $ tree
 │   │       └── test_helper.exs
 │   └── utilities
 │       ├── README.md
-│       ├── config
-│       │   └── config.exs
 │       ├── lib
 │       │   └── utilities.ex
 │       ├── mix.exs

--- a/en/lessons/basics/mix.md
+++ b/en/lessons/basics/mix.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Mix
 ---
 
@@ -30,8 +30,6 @@ From the output we can see that Mix has created our directory and a number of bo
 * creating .formatter.exs
 * creating .gitignore
 * creating mix.exs
-* creating config
-* creating config/config.exs
 * creating lib
 * creating lib/example.ex
 * creating test


### PR DESCRIPTION
Since `mix new` no longer generates the `config/` directory as of Elixir v1.9.0, the bash outputs for `mix new` occurring in `basics/mix.md` and `advanced/umbrella-projects.md` ought to be updated to reflect the new behaviour