### PR TITLE
`Scheduler` module expects singular `health_check` option

### DIFF
--- a/en/lessons/libraries/bypass.md
+++ b/en/lessons/libraries/bypass.md
@@ -212,7 +212,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "health checks are run and results logged" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->

--- a/es/lessons/libraries/bypass.md
+++ b/es/lessons/libraries/bypass.md
@@ -207,7 +207,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "health checks are run and results logged" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->

--- a/pt/lessons/libraries/bypass.md
+++ b/pt/lessons/libraries/bypass.md
@@ -211,7 +211,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "health checks are run and results logged" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->

--- a/ru/lessons/libraries/bypass.md
+++ b/ru/lessons/libraries/bypass.md
@@ -212,7 +212,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "проверки работоспособности работают и результаты записаны" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->

--- a/zh-hans/lessons/libraries/bypass.md
+++ b/zh-hans/lessons/libraries/bypass.md
@@ -186,7 +186,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "health checks are run and results logged" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->

--- a/zh-hant/lessons/libraries/bypass.md
+++ b/zh-hant/lessons/libraries/bypass.md
@@ -212,7 +212,7 @@ defmodule Clinic.SchedulerTest do
   end
 
   test "health checks are run and results logged" do
-    opts = [health_checks: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
+    opts = [health_check: TestCheck, interval: 1, sites: ["http://example.com", "http://example.org"]]
 
     output =
       capture_log(fn ->


### PR DESCRIPTION
This PR fixes a typo in the [lesson](https://elixirschool.com/en/lessons/libraries/bypass/) for [Bypass](https://github.com/PSPDFKit-labs/bypass/).

The test [here](https://github.com/elixirschool/elixirschool/blame/master/en/lessons/libraries/bypass.md#L215) passes in a `health_checks` option, but the receiving code actually requires `health_check` as seen [here](https://github.com/elixirschool/elixirschool/blame/master/en/lessons/libraries/bypass.md#L168):

```elixir
def init(opts) do
  # ...
  health_check = Keyword.get(opts, :health_check, HealthCheck)
  # ...
end
```
