### PR TITLE
the method change must be using the atom key

### DIFF
--- a/en/lessons/ecto/changesets.md
+++ b/en/lessons/ecto/changesets.md
@@ -75,12 +75,12 @@ It is useful when you trust the source making the changes or when you work with 
 Now we can create changesets, but since we do not have validation, any changes to person's name will be accepted, so we can end up with an empty name:
 
 ```elixir
-iex> Ecto.Changeset.change(%Friends.Person{name: "Bob"}, %{"name" => ""})
-%Ecto.Changeset<
+iex> Ecto.Changeset.change(%Friends.Person{name: "Bob"}, %{name: ""})
+#Ecto.Changeset<
   action: nil,
-  changes: %{name: nil},
+  changes: %{name: ""},
   errors: [],
-  data: %Friends.Person<>,
+  data: #Friends.Person<>,
   valid?: true
 >
 ```


### PR DESCRIPTION
I am using the Elixir 1.10.0.
And if I try the change like that it will get an ArgumentError:
> Ecto.Changeset.change(%Friends.Person{name: "Bob"}, %{"name" => ""})
** (ArgumentError) field names given to change/put_change must be atoms, got: `"name"`
    (ecto 3.4.0) lib/ecto/changeset.ex:1200: Ecto.Changeset.put_change/7
    (stdlib 3.10) maps.erl:232: :maps.fold_1/3
    (ecto 3.4.0) lib/ecto/changeset.ex:391: Ecto.Changeset.change/2
So the correct is using atoms keys.