### PR TITLE
[pt] add missing assignment in ecto/basics.md

### DIFF
--- a/pt/lessons/ecto/basics.md
+++ b/pt/lessons/ecto/basics.md
@@ -215,7 +215,7 @@ Como esperado, recebemos uma nova `Person` com o valor padrão aplicado a `age`.
 Agora, vamos criar uma pessoa "real":
 
 ```elixir
-iex> %Friends.Person{name: "Tom", age: 11}
+iex>  person = %Friends.Person{name: "Tom", age: 11}
 %Friends.Person{age: 11, name: "Tom"}
 ```
 


### PR DESCRIPTION
It needs to put the match 'person' for after do the `person.name`.