### PR TITLE
Make RSS feed more discoverable

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -34,6 +34,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}{% asset favicons/favicon-16x16.png @path %}">
   <link rel="manifest" href="{{ site.url }}{% asset favicons/manifest.json @path %}">
   <link rel="shortcut icon" href="{{ site.url }}{% asset favicons/favicon.ico @path %}">
+  <link rel="alternate" type="application/rss+xml" title="Elixir School" href="https://elixirschool.com/feed.xml" />
   <meta name="msapplication-config" content="{{ site.url }}{% asset favicons/browserconfig.xml @path %}">
   <meta name="theme-color" content="#ffffff">
 

--- a/_includes/share-icons.html
+++ b/_includes/share-icons.html
@@ -5,6 +5,7 @@
     {% assign title = page.title %}
   {% endif %}
   <li><iframe src="https://ghbtns.com/github-btn.html?user=elixirschool&repo=elixirschool&type=star&count=true" height="20" title="GitHub Stars" width="93" style="vertical-align: sub;"></iframe></li>
+  <li><a target="_blank" rel="noopener" title="RSS" href="https://elixirschool.com/feed.xml" class="icon fa-rss-square"><span class="label">RSS</span></a></li>
   <li><a target="_blank" rel="noopener" title="LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ page.url }}&title={{ title }}&summary=description&source={{ site.url }}" class="icon fa-linkedin"><span class="label">Linkedin</span></a></li>
   <li><a target="_blank" rel="noopener" title="Twitter" href="https://twitter.com/intent/tweet?url={{ site.url }}{{ page.url }}&via=elixirschool&text=ElixirSchool: {{ title }}&hashtags=learnelixir%2Celixirlang&" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
   <li><a target="_blank" rel="noopener" title="Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}" class="icon fa-facebook"><span class="label">Facebook</span></a></li>


### PR DESCRIPTION
I wanted to subscribe to the blog and couldn't find the feed.

This PR:

* Adds a `<link>` tag to the RSS feed to make it discoverable to browsers (and users)
* Adds a link with icon to the share icons section of the header to make the feed more discoverable to users

<img width="1072" alt="Image 2020-03-30 at 3 24 45 pm" src="https://user-images.githubusercontent.com/6588/77923959-081f7c80-729b-11ea-859d-d3bed7854be1.png">

I couldn't find whether the `feed.xml` was localised. I'm guessing the future it would be nice if the feed was localised and then we could link to the correct feed for each language.