### PR TITLE
Update ex_doc lesson

### DIFF
--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -199,8 +199,7 @@ In the `mix.exs` file, add the two required dependencies to get started: `:earma
 
 ```elixir
   def deps do
-    [{:earmark, "~> 1.2", only: :dev},
-    {:ex_doc, "~> 0.19", only: :dev}]
+    [{:ex_doc, "~> 0.21", only: :dev, runtime: false}]
   end
 ```
 

--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -195,7 +195,7 @@ Examples
 ### Installing
 
 Assuming all is well and we're seeing the output above, we are now ready to set up ExDoc.
-In the `mix.exs` file, add the two required dependencies to get started: `:earmark` and `:ex_doc`.
+In the `mix.exs` file, add the `:ex_doc` dependency to get started.
 
 ```elixir
   def deps do
@@ -203,11 +203,13 @@ In the `mix.exs` file, add the two required dependencies to get started: `:earma
   end
 ```
 
-We specify the `only: :dev` key-value pair as we don't want to download and compile these dependencies in a production environment.
-But why Earmark? Earmark is a Markdown parser for the Elixir programming language that ExDoc utilizes to turn our documentation within `@moduledoc` and `@doc` to beautiful looking HTML.
+We specify the `only: :dev` key-value pair as we don't want to download and compile the `ex_doc` dependency in a production environment.
 
-It is worth noting at this point that you are not forced to use Earmark.
-You can change the markup tool to others such as Pandoc, Hoedown, or Cmark; however you will need to do a little more configuration which you can read about [here](https://github.com/elixir-lang/ex_doc#changing-the-markdown-tool).
+`ex_doc` will also add another library for us, Earmark.
+
+Earmark is a Markdown parser for the Elixir programming language that ExDoc utilizes to turn our documentation within `@moduledoc` and `@doc` to beautiful looking HTML.
+
+It is worth noting at this point that you change the markup tool to Cmark if you wish, but you will need to do a little more configuration which you can read about [here](https://hexdocs.pm/ex_doc/ExDoc.Markdown.html#module-using-cmark).
 For this tutorial, we'll just stick with Earmark.
 
 ### Generating Documentation


### PR DESCRIPTION
This PR:

* Changes the `deps` line to remove Earmark and bump the version as per the current `ex_doc` version. Earmark is pulled in fine so it's not required explicitly. 

* Removes references to Pandoc and Hoedown and they are both no longer supported. Only Cmark remains as a supported alternative - removal of [Pandoc](https://github.com/elixir-lang/ex_doc/commit/62c774429592b0a84eac8bade58d518e046c49e7) and [Hoedown](https://github.com/elixir-lang/ex_doc/commit/5682997004627dfb140736a2e88215d2e76bf25e#diff-04c6e90faac2675aa89e2176d2eec7d8).

* Updates the link to the Cmark documentation as it was [re-organised here](https://github.com/elixir-lang/ex_doc/commit/060ef259e96bfc0e158c7d5e5d3a59b208c37e2b#diff-04c6e90faac2675aa89e2176d2eec7d8).