### PR TITLE
Small improvements to Telemetry Part One

### DIFF
--- a/_posts/2020-04-22-instrumenting-phoenix-with-telemetry-part-one.md
+++ b/_posts/2020-04-22-instrumenting-phoenix-with-telemetry-part-one.md
@@ -361,6 +361,24 @@ defmodule Quantum.Telemetry.StatsdReporter do
 end
 ```
 
+We need to start the `StatsdReporter` in our application's `start/2` function:
+
+```elixir
+# lib/quantum/application.ex
+
+def start(_, _) do
+  :ok = Quantum.Telemetry.StatsdReporter.connect()
+  :ok = :telemetry.attach(
+    # unique handler id
+    "quantum-telemetry-metrics",
+    [:phoenix, :request],
+    &Quantum.Telemetry.Metrics.handle_event/4,
+    nil
+  )
+  ...
+end
+```
+
 Now we can call on our `Quantum.Telemetry.StatsdReporter` in our event handler to emit metrics to StatsD:
 
 ```elixir

--- a/_posts/2020-04-22-instrumenting-phoenix-with-telemetry-part-one.md
+++ b/_posts/2020-04-22-instrumenting-phoenix-with-telemetry-part-one.md
@@ -22,7 +22,7 @@ In Part I we'll start out by setting up a basic, DIY Telemetry pipeline and exam
 
 ## Introduction
 
-In this post we'll discuss why observability matters and how Telemetry helps us treat observability like a first class citizen in Elixir projects. Then, we'll hand-roll our own instrumentation pipeline using Telemetry and StatsD. We'll wrap up with a look under the hood of the Telemetry library and set ourselves for Part II of this series, in which we leverage the `Telemetry.Metrics` library for even easier instrumentation and reporting.
+In this post we'll discuss why observability matters and how Telemetry helps us treat observability like a first class citizen in Elixir projects. Then, we'll hand-roll our own instrumentation pipeline using Telemetry and StatsD. We'll wrap up with a look under the hood of the Telemetry library and set ourselves up for Part II of this series, in which we leverage the `Telemetry.Metrics` library for even easier instrumentation and reporting.
 
 ## Observability Matters
 


### PR DESCRIPTION
I wasn't 100% sure if the added "up" in https://github.com/elixirschool/elixirschool/commit/b7083e867243a19f9ca8c5b5258be3dbebbae5b7 was necessary, so ignore it if not :)

The second commit https://github.com/elixirschool/elixirschool/commit/930515974d2b9eca72304f766ae33c202162d64e adds starting the `StatsdReporter` in `application.ex`. This [is _in_ the follow along code repo](https://github.com/elixirschool/telemetry-code-along/blob/part-1-solution/lib/quantum/application.ex#L9), but not in the article. I wasn't sure if that was on-purpose or not?
