### PR TITLE
Fix sidebar disappearing

### DIFF
--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -16,6 +16,12 @@
 		'small-to-xlarge': '(min-width: 481px) and (max-width: 1680px)'
 	});
 
+	$(window).on('load', function() {
+		setTimeout(function() {
+			$('body').removeClass('is-loading');
+		}, 100);
+	});
+
 	$(function() {
 
 		var	$window = $(window),
@@ -33,16 +39,11 @@
 		// That means it will be `undefined` if cookie does not exist.
 		if (!$theme) $theme = 'light';
 
-		// Disable animations/transitions ...
+		if ($theme === 'dark') {
+			toggleThemeIcon($elToggleTheme);
+		}
 
-			// ... until the page has loaded.
-				$body.addClass('is-loading');
-				if ($theme === 'dark') {
-					toggleThemeIcon($elToggleTheme);
-				}
-				setTimeout(function() {
-					$body.removeClass('is-loading');
-				}, 100);
+		// Disable animations/transitions ...
 
 			// ... when resizing.
 				var resizeTimeout;

--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -40,12 +40,9 @@
 				if ($theme === 'dark') {
 					toggleThemeIcon($elToggleTheme);
 				}
-				$window.on('load', function() {
-
-					setTimeout(function() {
-						$body.removeClass('is-loading');
-					}, 100);
-				});
+				setTimeout(function() {
+					$body.removeClass('is-loading');
+				}, 100);
 
 			// ... when resizing.
 				var resizeTimeout;
@@ -231,7 +228,7 @@
 					$body.toggleClass('dark');
 					toggleThemeIcon($elToggleTheme);
 				});
-				
+
 			// Polyfill for sidebar
 				Stickyfill.add($('#sidebar > .inner'));
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 {% assign locale = site.data['locales'][language] %}
 <html lang="{{ language }}{% if locale.lang_country %}-{{ locale.lang_country }}{% endif %}">
 	{% include _head.html %}
-	<body>
+	<body class="is-loading">
     <script type="text/javascript">
     var $theme = Cookies.get('theme');
     if ($theme === 'dark') document.body.classList.add("dark");


### PR DESCRIPTION
Closes #2302

The problem was that the removal of the `is-loading` was happening inside a window load event. But the event listener was sometimes been added after the page was already loaded, causing it to never be triggered.

The proposed solution is to just call the setTimeout that remove the class right after, inside the window ready event listener to avoid the race conditions.