### PR TITLE
[en] Fix the heading levels of the debugging lesson

### DIFF
--- a/en/lessons/specifics/debugging.md
+++ b/en/lessons/specifics/debugging.md
@@ -9,21 +9,21 @@ In this lesson we'll learn about debugging Elixir code as well as static analysi
 
 {% include toc.html %}
 
-# IEx
+## IEx
 
-The most straightforward tool we have for debugging Elixir code is IEx. 
+The most straightforward tool we have for debugging Elixir code is IEx.
 
 But don't be fooled by its simplicity - you can solve most of the issues with your application by it.
 
-IEx means `Elixir's interactive shell`.  
+IEx means `Elixir's interactive shell`.
 
 You could have already seen IEx in one of the previous lessons like [Basics](../../basics/basics) where we ran Elixir code interactively in the shell.
 
-The idea here is simple. 
+The idea here is simple.
 
 You get the interactive shell in the context of the place you want to debug.
 
-Let's try it. 
+Let's try it.
 
 To do that, create a file named `test.exs` and put this into the file:
 
@@ -49,9 +49,9 @@ warning: variable "b" is unused (if the variable is not meant to be used, prefix
 34
 ```
 
-But now let's get to the exciting part - the debugging. 
+But now let's get to the exciting part - the debugging.
 
-Put `require IEx; IEx.pry` in the line after `b = 0` and let's try running it once again. 
+Put `require IEx; IEx.pry` in the line after `b = 0` and let's try running it once again.
 
 You'll get something like this:
 
@@ -64,11 +64,11 @@ Cannot pry #PID<0.92.0> at TestMod.sum/1 (test.exs:5). Is an IEx shell running?
 34
 ```
 
-You should note that vital message. 
+You should note that vital message.
 
-When running an application, as usual, IEx outputs this message instead of blocking execution of the program. 
+When running an application, as usual, IEx outputs this message instead of blocking execution of the program.
 
-To run it properly you need to prepend your command with `iex -S`. 
+To run it properly you need to prepend your command with `iex -S`.
 
 What this does is it runs `mix` inside the `iex` command so that it runs the application in a special mode, such that calls to `IEx.pry` stop the application execution.
 
@@ -128,25 +128,25 @@ BREAK: (a)bort (c)ontinue (p)roc info (i)nfo (l)oaded
 
 To quit IEx, you can either hit `Ctrl+C` two times to exit the app, or type `continue` to go to the next breakpoint.
 
-As you can see, you can run any Elixir code. 
+As you can see, you can run any Elixir code.
 
-However, the limitation is that you can't modify variables of existing code, due to language immutability. 
+However, the limitation is that you can't modify variables of existing code, due to language immutability.
 
-However, you can get values of all the variables and run any computations. 
+However, you can get values of all the variables and run any computations.
 
-In this case, the bug would be in `b` reassigned to 0, and `sum` function being buggy as a result. 
+In this case, the bug would be in `b` reassigned to 0, and `sum` function being buggy as a result.
 
 Sure, language has already caught this bug even on the first run, but that's an example!
 
 ### IEx.Helpers
 
-One of the more annoying parts of working with IEx is it has no history of commands you used in previous runs. 
+One of the more annoying parts of working with IEx is it has no history of commands you used in previous runs.
 
 For solving that problem, there is a separate subsection on [IEx documentation](https://hexdocs.pm/iex/IEx.html#module-shell-history), where you can find the solution for your platform of choice.
 
 You can also look through the list of other available helpers in [IEx.Helpers documentation](https://hexdocs.pm/iex/IEx.Helpers.html).
 
-# Dialyxir and Dialyzer
+## Dialyxir and Dialyzer
 
 The [Dialyzer](http://erlang.org/doc/man/dialyzer.html), a **DI**screpancy **A**na**LYZ**er for **ER**lang programs is a tool for static code analysis.
 In other words they _read_ but do not _run_ code and analyse it e.g.
@@ -195,7 +195,7 @@ dialyzer --build_plt --output_plt /.dialyxir_core_18_1.3.2.plt --apps erts kerne
 done (warnings were emitted)
 ```
 
-## Static analysis of code
+### Static analysis of code
 
 Now we're ready to use Dialyxir:
 
@@ -235,7 +235,7 @@ done (passed successfully)
 
 Using specifications with tools to perform static code analysis helps us make code that is self-tested and contains less bugs.
 
-# Debugging
+## Debugging
 
 Sometimes static analysis of code is not enough.
 It may be necessary to understand the execution flow in order to find bugs.
@@ -295,7 +295,7 @@ After we've attached our module to the debugger it will be available in the menu
 
 ![Debugger Screenshot 2]({% asset debugger_2.png @path %})
 
-## Creating breakpoints
+### Creating breakpoints
 
 A breakpoint is a point in the code where execution will be halted.
 We have two ways of creating breakpoints:


### PR DESCRIPTION
The heading of the lesson content should starts with `h2`.

Before:

![image](https://user-images.githubusercontent.com/1198528/83083868-e0da0580-a0b9-11ea-918f-b0b497bf7212.png)

After:

![image](https://user-images.githubusercontent.com/1198528/83083976-30203600-a0ba-11ea-8171-faabc88d9e9c.png)
