### PR TITLE
fix(otp-distribution): add use Mix.Config line

### DIFF
--- a/en/lessons/advanced/otp-distribution.md
+++ b/en/lessons/advanced/otp-distribution.md
@@ -465,6 +465,7 @@ config :chat, remote_supervisor: fn(_recipient) -> Chat.TaskSupervisor end
 Remember to uncomment this line in `config/config.exs`:
 
 ```elixir
+use Mix.Config
 import_config "#{Mix.env()}.exs"
 ```
 


### PR DESCRIPTION
It seems like `use Mix.Config` line is missing in `config/config.exs` file [here](https://elixirschool.com/en/lessons/advanced/otp-distribution/#environment-specific-application-configuration).