### PR TITLE
Corrected reference to Mox article

### DIFF
--- a/en/lessons/basics/testing.md
+++ b/en/lessons/basics/testing.md
@@ -192,4 +192,4 @@ To leverage this "mocks-as-a-noun" pattern you can:
 * Define the mock module
 * Configure your application code to use the mock in the given test or test environment, for example by passing the mock module into a function call as an argument or by configuring your application to use the mock module in the test environment.
 
-For a deeper dive into test mocks in Elixir, and a look at the Mox library that allows you to define concurrent mock, check out our lesson on Mox [here](../libraries/mox)
+For a deeper dive into test mocks in Elixir, and a look at the Mox library that allows you to define concurrent mock, check out our lesson on Mox [here](../../libraries/mox)

--- a/en/lessons/libraries/mox.md
+++ b/en/lessons/libraries/mox.md
@@ -1,4 +1,5 @@
-version: 1.0
+---
+version: 1.0.0
 title: Mox
 ---
 


### PR DESCRIPTION
The article regarding Mix had its metadata tag incorrectly written, and the reference to it was also broken (leads to [404](https://elixirschool.com/en/lessons/basics/libraries/mox)) in the testing article.