### PR TITLE
Add sentence about DB Roles to Ecto Basics

### DIFF
--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -71,8 +71,7 @@ config :friends, Friends.Repo,
   hostname: "localhost"
 ```
 
-This configures how Ecto will connect to the database. Either edit the username to match one of your existing database roles, or create a new one in your `psql` shell as follows: 
-`CREATE ROLE user WITH SUPERUSER CREATEDB LOGIN PASSWORD 'pass';`
+This configures how Ecto will connect to the database. You may need to configure your database to have a matching credentials.
 
 It also creates a `Friends.Repo` module inside `lib/friends/repo.ex`
 

--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -72,7 +72,7 @@ config :friends, Friends.Repo,
 ```
 
 This configures how Ecto will connect to the database. Either edit the username to match one of your existing database roles, or create a new one in your `psql` shell as follows: 
-`CREATE ROLE postgres  WITH SUPERUSER CREATEDB LOGIN PASSWORD 'pass';`
+`CREATE ROLE user WITH SUPERUSER CREATEDB LOGIN PASSWORD 'pass';`
 
 It also creates a `Friends.Repo` module inside `lib/friends/repo.ex`
 

--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -71,7 +71,8 @@ config :friends, Friends.Repo,
   hostname: "localhost"
 ```
 
-This configures how Ecto will connect to the database.
+This configures how Ecto will connect to the database. Either edit the username to match one of your existing database roles, or create a new one in your `psql` shell as follows: 
+`CREATE ROLE postgres  WITH SUPERUSER CREATEDB LOGIN PASSWORD 'pass';`
 
 It also creates a `Friends.Repo` module inside `lib/friends/repo.ex`
 


### PR DESCRIPTION
Got a little stuck in the tutorial, turns out I didn't have a role called `postgres`. Thought it'd be nice to show how to fix that.