### PR TITLE
Added `redirect_from` directive to Nerves lesson

### DIFF
--- a/en/lessons/specifics/nerves.md
+++ b/en/lessons/specifics/nerves.md
@@ -1,6 +1,8 @@
 ---
 version: 1.0.1
 title: Nerves
+redirect_from:
+  - /en/lessons/advanced/nerves
 ---
 
 {% include toc.html %}

--- a/es/lessons/specifics/nerves.md
+++ b/es/lessons/specifics/nerves.md
@@ -1,6 +1,8 @@
 ---
 version: 1.0.0
 title: Nerves
+redirect_from:
+  - /es/lessons/advanced/nerves
 ---
 
 ## Introducción y requerimientos

--- a/ja/lessons/specifics/nerves.md
+++ b/ja/lessons/specifics/nerves.md
@@ -1,6 +1,8 @@
 ---
 version: 1.0.0
 title: Nerves
+redirect_from:
+  - /ja/lessons/advanced/nerves
 ---
 
 ## はじめに

--- a/zh-hans/lessons/specifics/nerves.md
+++ b/zh-hans/lessons/specifics/nerves.md
@@ -1,6 +1,8 @@
 ---
 version: 1.0.0
 title: Nerves
+redirect_from:
+  - /zh-hans/lessons/advanced/nerves
 ---
 
 ## Nerves 简介

--- a/zh-hant/lessons/specifics/nerves.md
+++ b/zh-hant/lessons/specifics/nerves.md
@@ -1,6 +1,8 @@
 ---
 version: 1.0.0
 title: Nerves
+redirect_from:
+  - /zh-hant/lessons/advanced/nerves
 ---
 
 ## 簡介和硬體需求


### PR DESCRIPTION
Moving Nerves broke cached Google Search results, this fixes the issue by redirecting old URLs back to the new location.

Fixes: #2367 