### PR TITLE
Add [rel="noopener"] to GitHub links

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,7 +15,7 @@ layout: default
     
     <blockquote class="edit-lesson">    
       Caught a mistake or want to contribute to the lesson?
-      <a href="https://github.com/elixirschool/elixirschool/edit/master/{{ page.path }}" target="_blank">
+      <a href="https://github.com/elixirschool/elixirschool/edit/master/{{ page.path }}" target="_blank" rel="noopener">
         Edit this page on GitHub!
       </a>
     </blockquote>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,7 +36,7 @@ layout: default
 
     <blockquote class="edit-lesson">
       Caught a mistake or want to contribute to the article?
-      <a href="https://github.com/elixirschool/elixirschool/edit/master/{{ page.path }}" target="_blank">
+      <a href="https://github.com/elixirschool/elixirschool/edit/master/{{ page.path }}" target="_blank" rel="noopener">
         Edit this page on GitHub!
       </a>
     </blockquote>


### PR DESCRIPTION
External links using `[target="_blank"]` must have `[rel="noopener"]` to deny access to `window.opener`. Only GitHub links were missing this attribute.