### PR TITLE
Add missing highlighting to code blocks

### DIFF
--- a/en/lessons/advanced/otp-distribution.md
+++ b/en/lessons/advanced/otp-distribution.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: OTP Distribution
 ---
 
@@ -125,7 +125,7 @@ We'll build a simple supervisor application that leverages distributed tasks to 
 
 Generate your app:
 
-```
+```shell
 mix new chat --sup
 ```
 

--- a/en/lessons/basics/date-time.md
+++ b/en/lessons/basics/date-time.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Date and Time
 ---
 
@@ -93,7 +93,7 @@ But be aware about timezones. The official docs state:
 
 Also, note that you can create a DateTime instance from the NaiveDateTime, just by providing the timezone:
 
-```
+```elixir
 iex> DateTime.from_naive(~N[2016-05-24 13:26:08.003], "Etc/UTC")
 {:ok, #DateTime<2016-05-24 13:26:08.003Z>}
 ```
@@ -104,13 +104,13 @@ As we have noted in the previous chapter, by default Elixir does not have any ti
 To solve this issue, we need to install and set up the [tzdata](https://github.com/lau/tzdata) package.
 After installing it, you should globally configure Elixir to use Tzdata as timezone database:
 
-```
+```elixir
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 ```
 
 Let's now try creating time in Paris timezone and convert it to New York time:
 
-```
+```elixir
 iex> paris_datetime = DateTime.from_naive!(~N[2019-01-01 12:00:00], "Europe/Paris")
 #DateTime<2019-01-01 12:00:00+01:00 CET Europe/Paris>
 iex> {:ok, ny_datetime} = DateTime.shift_zone(paris_datetime, "America/New_York")

--- a/en/lessons/libraries/distillery.md
+++ b/en/lessons/libraries/distillery.md
@@ -1,5 +1,5 @@
 ---
-version: 2.0.3
+version: 2.0.4
 title: Distillery (Basics)
 ---
 
@@ -41,11 +41,8 @@ end
 
 Then in your terminal call:
 
-```
+```shell
 mix deps.get
-```
-
-```
 mix compile
 ```
 
@@ -54,7 +51,7 @@ mix compile
 
 In your terminal, run
 
-```
+```shell
 mix release.init
 ```
 
@@ -135,7 +132,7 @@ If you executed the above command, you might have noticed that your application 
 This can be rectified by running an Ecto `mix` command.
 In your terminal, type the following:
 
-```
+```shell
 MIX_ENV=prod mix ecto.create
 ```
 
@@ -182,7 +179,7 @@ The [Ecto.Migrator](https://hexdocs.pm/ecto/2.2.8/Ecto.Migrator.html) allows us 
 Next, create a new file - `rel/hooks/post_start/migrate.sh` and add the following code:
 
 
-```
+```bash
 echo "Running migrations"
 
 bin/book_app rpc "Elixir.BookApp.ReleaseTasks.migrate"
@@ -243,7 +240,7 @@ end
 
 Next, create a new file `rel/commands/seed.sh` and add the following code:
 
-```
+```bash
 #!/bin/sh
 
 release_ctl eval "BookAppWeb.ReleaseTasks.seed/0"

--- a/en/lessons/libraries/nimble-publisher.md
+++ b/en/lessons/libraries/nimble-publisher.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.2
 title: NimblePublisher
 ---
 
@@ -19,7 +19,7 @@ Let's build our own blog. In our example, we're using a Phoenix application but 
 
 First, let's create a new Phoenix application for our example. We'll call it NimbleSchool, and we'll create it like this because we don't need Ecto where we're going:
 
-```
+```shell
 mix phx.new nimble_school --no-ecto
 ```
 

--- a/en/lessons/libraries/stream-data.md
+++ b/en/lessons/libraries/stream-data.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: StreamData
 ---
 
@@ -46,7 +46,7 @@ Just replace `x` and `y` with the version of StreamData shown in the library's [
 
 Third, run this from the command line of your terminal:
 
-```
+```shell
 mix deps.get
 ```
 
@@ -450,7 +450,7 @@ end
 
 You can run your tests by entering this on your terminal's command line:
 
-```
+```shell
 mix test
 ```
 

--- a/en/lessons/specifics/debugging.md
+++ b/en/lessons/specifics/debugging.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.2
+version: 1.1.3
 title: Debugging
 ---
 
@@ -27,7 +27,7 @@ Let's try it.
 
 To do that, create a file named `test.exs` and put this into the file:
 
-```
+```elixir
 defmodule TestMod do
   def sum([a, b]) do
     b = 0
@@ -41,7 +41,7 @@ IO.puts(TestMod.sum([34, 65]))
 
 And if you run it - you'll get an apparent output of `34`:
 
-```
+```shell
 $ elixir test.exs
 warning: variable "b" is unused (if the variable is not meant to be used, prefix it with an underscore)
   test.exs:2
@@ -55,7 +55,7 @@ Put `require IEx; IEx.pry` in the line after `b = 0` and let's try running it on
 
 You'll get something like this:
 
-```
+```elixir
 $ elixir test.exs
 warning: variable "b" is unused (if the variable is not meant to be used, prefix it with an underscore)
   test.exs:2
@@ -75,7 +75,7 @@ What this does is it runs `mix` inside the `iex` command so that it runs the app
 For example, `iex -S mix phx.server` to debug your Phoenix application.
 In our case, it's going to be `iex -r test.exs` to require the file:
 
-```
+```elixir
 $ iex -r test.exs
 Erlang/OTP 21 [erts-10.3.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]
 
@@ -95,8 +95,8 @@ Allow? [Yn]
 
 After responding to the prompt via `y` or pressing Enter, you've entered the interactive mode.
 
-```
- $ iex -r test.exs
+```elixir
+$ iex -r test.exs
 Erlang/OTP 21 [erts-10.3.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]
 
 warning: variable "b" is unused (if the variable is not meant to be used, prefix it with an underscore)

--- a/en/lessons/specifics/nerves.md
+++ b/en/lessons/specifics/nerves.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Nerves
 redirect_from:
   - /en/lessons/advanced/nerves
@@ -76,7 +76,7 @@ In the case of a Raspberry Pi 3, you set `MIX_TARGET=rpi3`, but you can change t
 
 Let's set up our dependencies first:
 
-```
+```shell
 $ export MIX_TARGET=rpi3
 $ cd network_led
 $ mix deps.get


### PR DESCRIPTION
There were some code blocks that missed language specification.

Since there is no default language set for Jekyll, those code blocks ended up not being highlighted. 