### PR TITLE
Add text of　returns the value of the equation

### DIFF
--- a/bg/lessons/basics/pattern-matching.md
+++ b/bg/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Списъци
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/bn/lessons/basics/pattern-matching.md
+++ b/bn/lessons/basics/pattern-matching.md
@@ -29,6 +29,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/de/lessons/basics/pattern-matching.md
+++ b/de/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Lass uns das mit ein paar der collections probieren, die wir kennen:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/en/lessons/basics/pattern-matching.md
+++ b/en/lessons/basics/pattern-matching.md
@@ -31,6 +31,7 @@ Let's try that with some of the collections we know:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/es/lessons/basics/pattern-matching.md
+++ b/es/lessons/basics/pattern-matching.md
@@ -31,6 +31,7 @@ Vamos a intentar esto con algunas de las colecciones que conocemos:
 ```elixir
 # Listas
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/fr/lessons/basics/pattern-matching.md
+++ b/fr/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Essayons avec une collection:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/gr/lessons/basics/pattern-matching.md
+++ b/gr/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Λίστες
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/id/lessons/basics/pattern-matching.md
+++ b/id/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Mari coba dengan sebagian collection yang kita tahu:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/it/lessons/basics/pattern-matching.md
+++ b/it/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Ora proviamo con una delle collezioni che conosciamo:
 ```elixir
 # Liste
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/ja/lessons/basics/pattern-matching.md
+++ b/ja/lessons/basics/pattern-matching.md
@@ -31,6 +31,7 @@ iex> 2 = x
 ```elixir
 # リスト
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/ko/lessons/basics/pattern-matching.md
+++ b/ko/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # 리스트
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/ms/lessons/basics/pattern-matching.md
+++ b/ms/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Sekarang kita akan menguji beberapa 'collection' yang kita tahu:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/no/lessons/basics/pattern-matching.md
+++ b/no/lessons/basics/pattern-matching.md
@@ -31,6 +31,7 @@ La oss nå prøve med noen av kolleksjonene vi allerede er kjente med:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/pl/lessons/basics/pattern-matching.md
+++ b/pl/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ A teraz spróbujmy tego samego z kolekcjami:
 ```elixir
 # Listy
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/pt/lessons/basics/pattern-matching.md
+++ b/pt/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Vamos tentar isso com algumas das coleções que nós conhecemos:
 ```elixir
 # Listas
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/ru/lessons/basics/pattern-matching.md
+++ b/ru/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/sk/lessons/basics/pattern-matching.md
+++ b/sk/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Skúsme to s nejakou kolekciou, ktorú poznáme:
 ```elixir
 # Zoznamy
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/ta/lessons/basics/pattern-matching.md
+++ b/ta/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/th/lessons/basics/pattern-matching.md
+++ b/th/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/tr/lessons/basics/pattern-matching.md
+++ b/tr/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Simdi de koleksiyonlar (collections) ile deneyelim:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/uk/lessons/basics/pattern-matching.md
+++ b/uk/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/vi/lessons/basics/pattern-matching.md
+++ b/vi/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ Và thử với các kiểu tổ hợp:
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/zh-hans/lessons/basics/pattern-matching.md
+++ b/zh-hans/lessons/basics/pattern-matching.md
@@ -31,6 +31,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list

--- a/zh-hant/lessons/basics/pattern-matching.md
+++ b/zh-hant/lessons/basics/pattern-matching.md
@@ -30,6 +30,7 @@ iex> 2 = x
 ```elixir
 # Lists
 iex> list = [1, 2, 3]
+[1, 2, 3]
 iex> [1, 2, 3] = list
 [1, 2, 3]
 iex> [] = list


### PR DESCRIPTION
Currently, the example using the "Pattern Matching" List does not have the standard output as shown below.
So we fixed it.

https://elixirschool.com/en/lessons/basics/pattern-matching/

```
# Lists
iex> list = [1, 2, 3]
iex> [1, 2, 3] = list
[1, 2, 3]
...
```