### PR TITLE
Update poolboy.md

### DIFF
--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -151,7 +151,14 @@ defmodule PoolboyApp.Test do
     Task.async(fn ->
       :poolboy.transaction(
         :worker,
-        fn pid -> GenServer.call(pid, {:square_root, i}) end,
+        fn pid -> 
+          try do
+            GenServer.call(pid, {:square_root, i}) end
+          catch
+            e, r -> IO.inspect("poolboy transaction caught error: #{inspect(e)}, #{inspect(r)}")
+            :ok
+          end
+        end,
         @timeout
       )
     end)

--- a/en/lessons/libraries/poolboy.md
+++ b/en/lessons/libraries/poolboy.md
@@ -152,6 +152,9 @@ defmodule PoolboyApp.Test do
       :poolboy.transaction(
         :worker,
         fn pid -> 
+          # Let's wrap the genserver call in a try - catch block. This allows us to trap any exceptions
+          # that might be thrown and return the worker back to poolboy in a clean manner. It also allows
+          # the programmer to retrieve the error and potentially fix it.
           try do
             GenServer.call(pid, {:square_root, i}) end
           catch


### PR DESCRIPTION
Catching an exception thrown by GenServer.call in the transaction function. If we don't do this, a timeout de-commisions that specific worker and pretty soon the system stops responding since no workers are around