### PR TITLE
typo correction.

### DIFF
--- a/en/lessons/ecto/basics.md
+++ b/en/lessons/ecto/basics.md
@@ -181,7 +181,7 @@ Let's create our new schema at `lib/friends/person.ex`:
 defmodule Friends.Person do
   use Ecto.Schema
 
-  schema "people" do
+  schema "person" do
     field :name, :string
     field :age, :integer, default: 0
   end


### PR DESCRIPTION
changed 
`schema "people" do` 
to 
`schema "person" do`
like it is suggested her:

> While Ecto favors pluralize database table names, the schema is typically singular, so we'll create a `Person` schema to accompany our table.