### PR TITLE
[pl] Updated translation of lesson "Mix"

### DIFF
--- a/en/lessons/basics/mix.md
+++ b/en/lessons/basics/mix.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 title: Mix
 ---
 
@@ -142,7 +142,7 @@ Now we're prepared to add dependencies when the time comes.
 ## Environments
 
 Mix, much like Bundler, supports differing environments.
-Out of the box mix is configured to have three environments:
+Out of the box Mix is configured to have three environments:
 
 - `:dev` — The default environment.
 - `:test` — Used by `mix test`. Covered further in our next lesson.

--- a/pl/lessons/basics/mix.md
+++ b/pl/lessons/basics/mix.md
@@ -1,23 +1,29 @@
 ---
-version: 0.9.2
+version: 1.1.2
 title: Mix
 ---
 
-Zanim zajmiemy się bardziej zaawansowanymi aspektami Elixira musimy poznać mix. Jeżeli znasz Ruby to mix jest odpowiednikiem Bundlera, RubyGems i Rake. Jest to kluczowy element każdego projektu tworzonego w Elixirze i w tej lekcji przyjrzymy się najważniejszym jego funkcjom. By uzyskać pełną listę oferowanych funkcji, wpisz `mix help`.
+Zanim zajmiemy się bardziej zaawansowanymi aspektami Elixira musimy poznać Mix.
+Jeżeli znasz język Ruby, to można powiedzieć, że Mix stanowi połączenie Bundlera, RubyGems i Rake.
+Jest to kluczowy element każdego projektu tworzonego w Elixirze i w tej lekcji przyjrzymy się najważniejszym jego funkcjom.
+By uzyskać pełną listę oferowanych funkcji, wpisz `mix help`.
 
-Dotychczas pracowaliśmy z interpreterem `iex`, który ma dość ograniczone możliwości. Chcąc napisać coś bardziej rozbudowanego, musimy nasz projekt podzielić na wiele plików, by móc zarządzać kodem. Mix pozwala nam na efektywne zarządzanie projektem.
+Dotychczas pracowaliśmy z interpreterem `iex`, który ma dość ograniczone możliwości.
+Chcąc napisać coś bardziej rozbudowanego, musimy nasz kod podzielić na wiele plików, by móc nim efektywnie zarządzać; Mix pozwala nam to robić z projektami.
 
 {% include toc.html %}
 
 ## Nowy projekt
 
-Kiedy będziesz gotowy, by stworzyć swój pierwszy projekt w Elixirze zrób to poleceniem `mix new`. Generator stworzy strukturę katalogów oraz niezbędne pliki projektu. Jest to bardzo proste, a zatem zaczynajmy:
+Kiedy jesteśmy gotowi, by stworzyć nasz pierwszy projekt w Elixirze, możemy to zrobić za pomocą polecenia `mix new`.
+Generator stworzy strukturę katalogów oraz niezbędne pliki projektu.
+Jest to bardzo proste – zatem zaczynajmy:
 
 ```bash
 $ mix new example
 ```
 
-W konsoli pojawi się informacja, że mix stworzył niezbędne pliki oraz katalogi:
+W konsoli pojawi się informacja, że Mix stworzył niezbędne pliki oraz katalogi:
 
 ```bash
 * creating README.md
@@ -31,7 +37,9 @@ W konsoli pojawi się informacja, że mix stworzył niezbędne pliki oraz katalo
 * creating test/example_test.exs
 ```
 
-W tej lekcji skupimy się na pliku `mix.exs`. Skonfigurujemy naszą aplikację, zależności, środowisko oraz wersję. Otwórz plik w swoim ulubionym edytorze. Powinieneś zobaczyć coś w rodzaju (komentarze usunięte dla zwięzłości):
+W tej lekcji skupimy się na pliku `mix.exs`.
+Skonfigurujemy naszą aplikację, zależności, środowisko oraz wersję.
+Otwórz plik w swoim ulubionym edytorze – powinieneś zobaczyć coś takiego (komentarze usunęliśmy dla zwięzłości):
 
 ```elixir
 defmodule Example.Mix do
@@ -59,13 +67,16 @@ defmodule Example.Mix do
 end
 ```
 
-Pierwsza sekcja, której się przyjrzymy to `project`.  W niej definiujemy nazwę naszej aplikacji (`app`), określamy jej wersję (`version`), wersję Elixira (`elixir`) oraz listę zależności (`deps`).
+Pierwsza sekcja, której się przyjrzymy, to `project`.
+W niej definiujemy nazwę naszej aplikacji (`app`), określamy jej wersję (`version`), wersję Elixira (`elixir`) oraz listę zależności (`deps`).
 
-Sekcja `application` jest używana w czasie tworzenia pliku aplikacji. Przyjrzymy się jej w następnej kolejności.
+Sekcja `application` jest używana w czasie tworzenia pliku aplikacji, który omówimy dalej.
 
 ## Tryb interaktywny
 
-Może zajść potrzeba użycia `iex` w kontekście naszej aplikacji.  Na całe szczęście z mixem jest to proste. Wystarczy uruchomić nową sesję `iex` z parametrami:
+Może zajść potrzeba użycia `iex` w kontekście naszej aplikacji.
+Dzięki Mixowi jest to na szczęście proste.
+Wystarczy uruchomić nową sesję `iex` z parametrami:
 
 ```bash
 $ cd example
@@ -76,30 +87,34 @@ Tak uruchomiony `iex` załaduje na starcie aplikację wraz z zależnościami.
 
 ## Kompilacja
 
-Mix jest cwany i będzie kompilował tylko zmieniony kod, ale czasami zachodzi potrzeba skompilowania całego projektu. W tej części przyjrzymy się jak kompilować projekt i co robi kompilator.
+Mix jest cwany i będzie kompilował tylko zmieniony kod, ale czasami zachodzi potrzeba skompilowania całego projektu.
+W tej części przyjrzymy się jak kompilować projekt i co robi kompilator.
 
 Do skompilowania projektu wystarczy polecenie `mix compile` wywołane w katalogu głównym projektu:
+**Uwaga: polecenia Mixa specyficzne dla projektu są dostępne jedynie w głównym katalogu tego projektu – w innych lokalizacjach można użyć jedynie poleceń globalnych.**
 
 ```bash
 $ mix compile
 ```
 
-Nasz projekt nie zawiera zbyt wielu elementów, a zatem komunikat nie będzie zbyt ekscytujący, ale jednak liczymy na sukces:
+Nasz projekt nie zawiera zbyt wielu elementów, a zatem komunikat nie jest zbyt ekscytujący, ale kompilacja powinna zakończyć się powodzeniem:
 
 ```bash
 Compiled lib/example.ex
 Generated example app
 ```
 
-W trakcie kompilacji mix tworzy katalog `_build`, w którym umieści wyniki. Jak zajrzymy do katalogu `_build`, zobaczymy naszą skompilowaną aplikację: `example.app`.
+W trakcie kompilacji Mix tworzy katalog `_build`, w którym umieści wyniki.
+Jeśli zajrzymy do katalogu `_build`, zobaczymy naszą skompilowaną aplikację: `example.app`.
 
 ## Zarządzanie zależnościami
 
-Jak na razie nasz projekt nie ma żadnych zależności, ale nic nie stoi nam na przeszkodzie, by je dodać.
+Jak na razie nasz projekt nie ma żadnych zależności, ale nic nie stoi na przeszkodzie, by je dodać.
 
-Dodanie nowej zależności odbywa się w sekcji `deps` w pliku `mix.exs`. Lista zależności zawiera krotki o dwóch obowiązkowych elementach i jednym opcjonalnym: atomie reprezentującym nazwę pakietu, ciągu znaków określającym wersję oraz opcjonalnych przełącznikach.
+Aby dodać nową zależność, powinniśmy ją najpierw umieścić w sekcji `deps` pliku `mix.exs`.
+Lista zależności zawiera krotki o dwóch obowiązkowych elementach i jednym opcjonalnym: atomie reprezentującym nazwę pakietu, ciągu znaków określającym wersję oraz opcjonalnych przełącznikach.
 
-Rzućmy okiem na przykład na projekt [phoenix_slim](https://github.com/doomspork/phoenix_slim):
+Spójrzmy dla przykładu na projekt [phoenix_slim](https://github.com/doomspork/phoenix_slim):
 
 ```elixir
 def deps do
@@ -112,25 +127,29 @@ def deps do
 end
 ```
 
-Jak zapewne się domyślasz zależność `cowboy` jest potrzebna tylko w fazie rozwoju i testów aplikacji.
+Jak zapewne się domyślasz, zależność `cowboy` jest potrzebna tylko przy implementowaniu i testowaniu aplikacji.
 
-Jak już skonfigurujemy nasze zależności, trzeba je jeszcze pobrać. Jest to zachowanie analogiczne do `bundle install`:
+Kiedy nasze zależności są już skonfigurowane, pozostaje nam jeszcze jeden krok: pobranie ich.
+Jest to zachowanie analogiczne do `bundle install`:
 
 ```bash
 $ mix deps.get
 ```
 
-I to wszystko! Zdefiniowaliśmy i pobraliśmy nasze zależności. Teraz możemy ich użyć jak zajdzie potrzeba.
+I to wszystko! Zdefiniowaliśmy i pobraliśmy nasze zależności.
+Teraz możemy ich użyć jak zajdzie potrzeba.
 
 ## Środowiska
 
-Mix, tak jak Bundler, wspiera rozróżnianie środowisk. Domyślnie mamy zdefiniowane trzy z nich:
+Mix, tak jak Bundler, wspiera rozróżnianie środowisk.
+Domyślnie mamy zdefiniowane trzy z nich:
 
-+ `:dev` — Środowisko domyślne.
-+ `:test` — Używane przez `mix test`. Omówimy je w kolejnych lekcjach.
-+ `:prod` — Używane, gdy uruchamiamy aplikację na produkcji.
++ `:dev` — środowisko domyślne.
++ `:test` — używane przez `mix test`; omówimy je w kolejnych lekcjach.
++ `:prod` — używane, gdy uruchamiamy aplikację na produkcji.
 
-Aktualne środowisko dostępne jest w `Mix.env`.  I jak można się spodziewać, istnieje możliwość skonfigurowania go za pomocą zmiennej systemowej `MIX_ENV`:
+Aktualne środowisko dostępne jest w `Mix.env`.
+Jak można się spodziewać, istnieje możliwość skonfigurowania go za pomocą zmiennej środowiskowej `MIX_ENV`:
 
 ```bash
 $ MIX_ENV=prod mix compile


### PR DESCRIPTION
1. Updated translation of lesson "Mix" to match the latest version of this lessons in English version.
2. Style/punctuation/formatting updates.
3. "Typo" fixed in English version: in almost all places English article uses "Mix" (written with a capital letter), but in one place it was "mix" (written with a lowercase letter), so this plase has been updated.