### PR TITLE
[en] Add missing iex prompt to characters build_assoc code block example

### DIFF
--- a/en/lessons/ecto/associations.md
+++ b/en/lessons/ecto/associations.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.1
+version: 1.2.2
 title: Associations
 ---
 
@@ -315,7 +315,7 @@ iex> movie = Repo.insert!(movie)
 Now we'll build our associated character and insert it into the database:
 
 ```elixir
-character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
+iex> character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
 %Friends.Character{
   __meta__: %Ecto.Schema.Metadata<:built, "characters">,
   id: nil,
@@ -323,7 +323,7 @@ character = Ecto.build_assoc(movie, :characters, %{name: "Wade Watts"})
   movie_id: 1,
   name: "Wade Watts"
 }
-Repo.insert!(character)
+iex> Repo.insert!(character)
 %Friends.Character{
   __meta__: %Ecto.Schema.Metadata<:loaded, "characters">,
   id: 1,


### PR DESCRIPTION
## More Details
This specific Elixir code block inside the Ecto > Associations lesson was missing the `iex>` prompt to indicate statements.
This pull requests adds these prompt indicators to the example.