### PR TITLE
Blog Live View With Presence: Usage of broadcast_from doesn't match signature in docs

### DIFF
--- a/_posts/2019-05-06-live-view-with-presence.md
+++ b/_posts/2019-05-06-live-view-with-presence.md
@@ -156,7 +156,7 @@ Then, we need to teach our live view to broadcast new messages to these subscrib
 
 def handle_event("message", %{"message" => message_params}, socket) do
   chat = Chats.create_message(message_params)
-  PhatWeb.Endpoint.broadcast_from(self(), topic(chat.id), "message", %{chat: chat})
+  PhatWeb.Endpoint.broadcast_from(topic(chat.id), self(), "message", %{chat: chat})
   {:noreply, assign(socket, chat: chat, message: Chats.change_message())}
 end
 ```


### PR DESCRIPTION
Issue: https://github.com/elixirschool/elixirschool/issues/2496
I change the order of the parameter to second. 
#2496 
