### PR TITLE
Fixup codestyle markup

### DIFF
--- a/_posts/2019-05-06-live-view-with-presence.md
+++ b/_posts/2019-05-06-live-view-with-presence.md
@@ -255,7 +255,7 @@ The Presence process's state for the given topic will look something like this:
 
 When we call `Presence.track`, Presence will broadcast a `"presence_diff"` event over its PubSub backend. We told our Presence module to use the same PubSub server as the rest of the application––the very same server that backs our `PhatWeb.Endpoint`.
 
-Recall that our live view clients are subscribing to this PubSub server via the following call in the `mount/2` function: ` PhatWeb.Endpoint.subscribe(topic(chat.id))`. So, these subscribing LiveView processes will receive the `"presence_diff"` event, which looks something like this:
+Recall that our live view clients are subscribing to this PubSub server via the following call in the `mount/2` function: `PhatWeb.Endpoint.subscribe(topic(chat.id))`. So, these subscribing LiveView processes will receive the `"presence_diff"` event, which looks something like this:
 
 ```elixir
 %{


### PR DESCRIPTION
This PR should fix up the incorrect code style markup.
<img width="943" alt="Screenshot 2021-06-18 at 20 26 30" src="https://user-images.githubusercontent.com/12559188/122602662-84a2a480-d073-11eb-8155-b5e9479741fb.png">
