### PR TITLE
[PL] Translation of lesson "Documentation" (+ minor fixes in EN version)

### DIFF
--- a/en/lessons/basics/documentation.md
+++ b/en/lessons/basics/documentation.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 title: Documentation
 ---
 
@@ -84,7 +84,7 @@ defmodule Greeter do
   """
 
   @doc """
-  Prints a hello message
+  Prints a hello message.
 
   ## Parameters
 
@@ -109,14 +109,16 @@ end
 If we kick into IEx again and use the helper command (`h`) on the function prepended with the module name, we should see the following:
 
 ```elixir
-iex> c("greeter.ex")
+iex> c("greeter.ex", ".")
 [Greeter]
 
 iex> h Greeter.hello
 
                 def hello(name)
 
-Prints a hello message
+  @spec hello(String.t()) :: String.t()
+
+Prints a hello message.
 
 Parameters
 
@@ -177,7 +179,9 @@ iex> h Greeter.hello
 
                 def hello(name)
 
-Prints a hello message
+  @spec hello(String.t()) :: String.t()
+
+Prints a hello message.
 
 Parameters
 

--- a/pl/lessons/basics/documentation.md
+++ b/pl/lessons/basics/documentation.md
@@ -39,7 +39,7 @@ Tego rodzaju komentarze powinny być używane z umiarem, ponieważ w dużej licz
 ### Dokumentowanie modułów
 
 Adnotacja `@moduledoc` służy do dokumentowania modułów.
-Zazwyczaj umieszcza się ją w linii poniżej deklaracji `defmodule` na górze pliku
+Zazwyczaj umieszcza się ją w linii poniżej deklaracji `defmodule` na górze pliku.
 Poniższy przykład ilustruje użycie `@moduledoc`.
 
 ```elixir

--- a/pl/lessons/basics/documentation.md
+++ b/pl/lessons/basics/documentation.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.1
+version: 1.1.1
 title: Dokumentowanie kodu
 ---
 
@@ -9,17 +9,21 @@ Jak dokumentować kod Elixira.
 
 ## Adnotacje
 
-Nie ważne jak wiele komentarzy piszemy i jak dobra jest dokumentacja, to zawsze jej jakość będzie niewystarczająca. Pomimo to wszyscy wiemy, że dokumentacja jest istotna zarówno dla nas samych, jak i dla osób, które pracują lub będą pracować z naszym kodem.
+Nieważne, jak wiele komentarzy piszemy i jak dobra jest dokumentacja, to zawsze jej jakość będzie niewystarczająca.
+Pomimo to wszyscy wiemy, że dokumentacja jest istotna zarówno dla nas samych, jak i dla osób, które pracują lub będą pracować z naszym kodem.
 
-Elixir traktuje dokumentację jako byt podstawowy (ang. *first-class citizen*), oferując zestaw funkcji pozwalających na generowanie i pracę z dokumentacją w projekcie. Elixir dostarcza wiele różnych rozwiązań na poziomie kodu do tworzenia dokumentacji. Przyjrzyjmy się trzem z nich: 
+Elixir traktuje dokumentację jako byt podstawowy (ang. *first-class citizen*), oferując zestaw funkcji pozwalających na generowanie i pracę z dokumentacją w projekcie.
+Elixir dostarcza wiele różnych rozwiązań na poziomie kodu do tworzenia dokumentacji.
+Przyjrzyjmy się trzem z nich:
 
-  - `#` - Służy do komentowania kodu.
-  - `@moduledoc` - Pozwala na tworzenie dokumentacji modułów.
-  - `@doc` - Pozwala na tworzenie dokumentacji poszczególnych funkcji.
+  - `#` – Służy do komentowania kodu.
+  - `@moduledoc` – Pozwala na tworzenie dokumentacji modułów.
+  - `@doc` – Pozwala na tworzenie dokumentacji poszczególnych funkcji.
 
 ### Komentowanie kodu
 
-Najprostszą metodą dokumentowania kodu są komentarze. Podobnie jak w Pythonie i Ruby, tak w Elixirze komentarz rozpoczyna się znakiem `#`, zwanym *kratką* albo *hashem*.
+Najprostszą metodą dokumentowania kodu są komentarze.
+Podobnie jak w Pythonie i Rubym, tak w Elixirze komentarz rozpoczyna się znakiem `#`, zwanym *kratką* albo *hashem*.
 
 Popatrzymy na ten skrypt (greeting.exs):
 
@@ -28,16 +32,20 @@ Popatrzymy na ten skrypt (greeting.exs):
 IO.puts("Hello, " <> "chum.")
 ```
 
-Gdy go uruchomimy, Elixir zignoruje wszystko od znaku `#` aż do końca linii, traktując jako nieistotny i nieinterpretowany element. Komentarz nie ma żadnej wartości ani nie wpływa na szybkość wykonania kodu. Jednakże pozwala innym zrozumieć nasz kod. Tego rodzaju komentarze powinny być używane z umiarem, ponieważ w dużej liczbie zaśmiecają kod i zamiast pomagać, mogą przeszkadzać. Niektórzy programiści w ogóle nie uważają tego rodzaju komentarzy za przydatne.
+Gdy go uruchomimy, Elixir zignoruje wszystko od znaku `#` aż do końca linii, traktując jako nieistotny i nieinterpretowany element.
+Komentarz nie ma żadnej wartości ani nie wpływa na szybkość wykonania kodu, jednakże może pomóc innym zrozumieć nasz kod.
+Tego rodzaju komentarze powinny być używane z umiarem, ponieważ w dużej liczbie zaśmiecają kod i zamiast pomagać, mogą przeszkadzać, stając się dla niektórych koszmarem.
 
 ### Dokumentowanie modułów
 
-Adnotacja `@moduledoc` służy do dokumentowania modułów. Zazwyczaj umieszcza się ją w linii poniżej deklaracji `defmodule` na górze pliku. Poniższy przykład ilustruje użycie `@moduledoc`.
+Adnotacja `@moduledoc` służy do dokumentowania modułów.
+Zazwyczaj umieszcza się ją w linii poniżej deklaracji `defmodule` na górze pliku
+Poniższy przykład ilustruje użycie `@moduledoc`.
 
 ```elixir
 defmodule Greeter do
   @moduledoc """
-  Provides a function `hello/1` to greet a human
+  Zawiera funkcję `hello/1` do przywitania człowieka
   """
 
   def hello(name) do
@@ -47,6 +55,7 @@ end
 ```
 
 Dostęp do dokumentacji modułu w IEx jest możliwy z pomocą polecenia `h`.
+Możemy to sprawdzić sami, umieszczając nasz moduł `Greeter` w nowym pliku, `greeter.ex`, a następnie go kompilując:
 
 ```elixir
 iex> c("greeter.ex", ".")
@@ -59,9 +68,13 @@ iex> h Greeter
 Provides a function hello/1 to greet a human
 ```
 
+_Uwaga_: nie musimy ręcznie kompilować naszych plików, jak zrobiliśmy to powyżej, jeśli pracujemy w projekcie Mixa. W takim przypadku możemy użyć polecenia `iex -S mix`, by załadować konsolę IEx dla obecnego projektu.
+
 ### Dokumentowanie funkcji
 
-Elixir poza adnotacją pozwalającą na dokumentowanie modułów ma też adnotację służącą do dokumentowania poszczególnych funkcji. Adnotacja `@doc` jest umieszczana nad dokumentowaną funkcją.
+Elixir poza adnotacją pozwalającą na dokumentowanie modułów ma też adnotację służącą do dokumentowania poszczególnych funkcji.
+Adnotacja `@doc` pozwala na tworzenie wbudowanej dokumentacji na poziomie funkcji.
+Jest umieszczana nad dokumentowaną funkcją.
 
 ```elixir
 defmodule Greeter do
@@ -70,13 +83,13 @@ defmodule Greeter do
   """
 
   @doc """
-  Prints a hello message
+  Wyświetla wiadomość powitalną.
 
-  ## Parameters
+  ## Parametry
 
-    - name: String that represents the name of the person.
+    - name: Łańcuch znaków reprezentujący imię osoby.
 
-  ## Examples
+  ## Przykłady
 
       iex> Greeter.hello("Sean")
       "Hello, Sean"
@@ -92,23 +105,25 @@ defmodule Greeter do
 end
 ```
 
-W IEx za pomocą polecenia `h` możemy też dostać się do dokumentacji funkcji.
+W IEx za pomocą polecenia `h` możemy też dostać się do dokumentacji funkcji:
 
 ```elixir
-iex> c("greeter.ex")
+iex> c("greeter.ex", ".")
 [Greeter]
 
 iex> h Greeter.hello
 
                 def hello(name)
 
-`hello/1` prints a hello message
+  @spec hello(String.t()) :: String.t()
 
-Parameters
+Wyświetla wiadomość powitalną.
 
-  • name: String that represents the name of the person.
+Parametry
 
-Examples
+  • name: Łańcuch znaków reprezentujący imię osoby.
+
+Przykłady
 
     iex> Greeter.hello("Sean")
     "Hello, Sean"
@@ -119,11 +134,15 @@ Examples
 iex>
 ```
 
-Zauważ jak za pomocą znaczników, umożliwiliśmy terminalowi sformatowanie dokumentacji. Poza tym, że fajnie to wygląda i jest nowatorskim rozwiązaniem w ekosystemie Elixira, to daje nam duże możliwości przy generowaniu HTML-a z pomocą narzędzia ExDoc.
+Zauważ, jak za pomocą znaczników umożliwiliśmy terminalowi sformatowanie dokumentacji. Poza tym, że fajnie to wygląda i jest nowatorskim rozwiązaniem w ekosystemie Elixira, to daje nam duże możliwości przy generowaniu HTML-a z pomocą narzędzia ExDoc.
+
+**Uwaga:** adnotacja `@spec` jest używana do statycznej analizy kodu.
+Jeśli chcesz dowiedzieć się więcej na ten temat, zajrzyj do lekcji [Specyfikacje i typy](../../advanced/typespec).
 
 ## ExDoc
 
-ExDoc jest oficjalnym projektem zespołu Elixira służącym do **generowania HTML-a (HyperText Markup Language) i dokumentacji online dla projektów tworzonych w Elixirze**, które można znaleźć na [GitHub](https://github.com/elixir-lang/ex_doc). Na początek stwórzmy nowy projekt w mix-ie:
+ExDoc jest oficjalnym projektem zespołu Elixira służącym do **generowania HTML-a (HyperText Markup Language) i dokumentacji online dla projektów tworzonych w Elixirze**, które można znaleźć na [GitHub](https://github.com/elixir-lang/ex_doc).
+Na początek stwórzmy nowy projekt Mixa:
 
 ```bash
 $ mix new greet_everyone
@@ -149,20 +168,23 @@ $ cd greet_everyone
 
 ```
 
-Następnie skopiujmy adnotację `@doc` do pliku `lib/greeter.ex` i upewnijmy się, że nadal działa on z linii poleceń. Jako że pracujemy z mixem uruchommy IEx korzystając z polecenia `iex -S mix` i wpiszmy:
+Teraz skopiujmy adnotację `@doc` do pliku `lib/greeter.ex` i upewnijmy się, że nadal działa on z linii poleceń.
+Jako że pracujemy z Mixem, uruchommy IEx korzystając z polecenia `iex -S mix` i wpiszmy:
 
 ```bash
 iex> h Greeter.hello
 
                 def hello(name)
 
-Prints a hello message
+  @spec hello(String.t()) :: String.t()
 
-Parameters
+Wyświetla wiadomość powitalną.
 
-  • name: String that represents the name of the person.
+Parametry
 
-Examples
+  • name: Łańcuch znaków reprezentujący imię osoby.
+
+Przykłady
 
     iex> Greeter.hello("Sean")
     "Hello, Sean"
@@ -173,15 +195,20 @@ Examples
 
 ### Instalacja
 
-Wnioskując z powyższego komunikatu jesteśmy już gotowi by skonfigurować ExDoc. W pliku `mix.exs` musimy dodać dwie zależności `:earmark` i `:ex_doc`.
+Jak możemy wnioskować z powyższego komunikatu, jesteśmy już gotowi, by skonfigurować ExDoc.
+W pliku `mix.exs` musimy dodać zależności `:earmark` i `:ex_doc`.
 
 ```elixir
-def deps do
-  [{:earmark, "~> 0.1", only: :dev}, {:ex_doc, "~> 0.11", only: :dev}]
-end
+  def deps do
+    [{:ex_doc, "~> 0.21", only: :dev, runtime: false}]
+  end
 ```
 
-Podając opcję `only: :dev` mówimy mixowi, że nie chcemy pobierać i kompilować tych zależności na środowisku innym niż deweloperskie. Ale czym jest Earmark? Earmark jest to parser znaczników napisany dla Elixira, który służy ExDocowi  na zamianę dokumentacji z adnotacji `@moduledoc` i `@doc` na elegancki kod HTML.
+Podając opcję `only: :dev` mówimy Mixowi, że nie chcemy pobierać i kompilować tych zależności na środowisku innym niż deweloperskie.
+
+`ex_doc` doda również inną bibliotekę, Earmark.
+
+Earmark jest parserem znaczników napisanym dla Elixira, służącym ExDocowi do zamiany dokumentacji z adnotacji `@moduledoc` i `@doc` na elegancki kod HTML.
 
 Oczywiście nie jesteśmy ograniczeni tylko do Earmarka. Jak chcesz możesz zamienić go na Pandoc, Hoedown albo Cmark; to wymaga trochę dodatkowej konfiguracji, o której poczytasz [tutaj (ang.)](https://github.com/elixir-lang/ex_doc#changing-the-markdown-tool). Na potrzeby tej lekcji pozostaniemy jednak przy Earmarku.
 
@@ -197,7 +224,9 @@ Docs successfully generated.
 View them at "doc/index.html".
 ```
 
-Jeżeli wszystko poszło zgodnie z planem powinieneś zobaczyć komunikat taki jak wyżej. Jeżeli zajrzymy teraz do naszego projektu to w katalogu **doc/** odnajdziemy wygenerowaną dokumentację. Jeżeli otworzysz plik `index.html` w przeglądarce powinieneś zobaczyć:
+Jeżeli wszystko poszło zgodnie z planem powinieneś zobaczyć komunikat taki jak wyżej.
+Jeżeli zajrzymy teraz do naszego projektu, to w katalogu **doc/** odnajdziemy wygenerowaną dokumentację.
+Jeżeli otworzysz plik `index.html` w przeglądarce, powinieneś zobaczyć:
 
 ![ExDoc Screenshot 1]({% asset documentation_1.png @path %})
 
@@ -209,14 +238,16 @@ Możemy ją teraz umieścić na GitHubie, naszej stronie, albo w serwisie [HexDo
 
 ## Dobre praktyki
 
-Zasady tworzenia dokumentacji powinny być opisane w przewodniku dobrych praktyk języka. Jednakże Elixir jest jeszcze bardzo młodym językiem i wiele elementów jego ekosystemu musi zostać zestandaryzowanych, co oznacza, że dobre praktyki dla dokumentacji są tworzone przede wszystkim przez społeczność programistów. Można o tym poczytać, w dokumencie [TheElixir Style Guide](https://github.com/niftyn8/elixir_style_guide).
+Zasady tworzenia dokumentacji powinny być opisane w przewodniku dobrych praktyk języka.
+Jako że Elixir jest jeszcze bardzo młodym językiem, to wiele elementów jego ekosystemu musi zostać zestandaryzowanych, co oznacza, że dobre praktyki dla dokumentacji są tworzone przede wszystkim przez społeczność programistów.
+Można o tym poczytać, w dokumencie [TheElixir Style Guide](https://github.com/niftyn8/elixir_style_guide).
 
   - Zawsze dokumentuj moduły.
 
 ```elixir
 defmodule Greeter do
   @moduledoc """
-  This is good documentation.
+  To jest dobra dokumentacja.
   """
 
 end
@@ -231,14 +262,14 @@ defmodule Greeter do
 end
 ```
 
- - Jak odwołujesz się do funkcji w dokumentacji modułu, używaj apostrofów:
+ - Jak odwołujesz się do funkcji w dokumentacji modułu, używaj grawisów:
 
 ```elixir
 defmodule Greeter do
   @moduledoc """
   ...
 
-  This module also has a `hello/1` function.
+  Ten moduł zawiera również funkcję `hello/1`.
   """
 
   def hello(name) do
@@ -247,14 +278,14 @@ defmodule Greeter do
 end
 ```
 
- - Oddziel kod od `@moduledoc` pozostawiając wolną linię:
+ - Oddziel kod od `@moduledoc`, pozostawiając wolną linię:
 
 ```elixir
 defmodule Greeter do
   @moduledoc """
   ...
 
-  This module also has a `hello/1` function.
+  Ten moduł zawiera również funkcję `hello/1`.
   """
 
   alias Goodbye.bye_bye
@@ -266,7 +297,7 @@ defmodule Greeter do
 end
 ```
 
- - Używaj znaczników w dokumentowaniu funkcji by łatwiej było czytać ją w  IEx lub ExDoc.
+ - Używaj znaczników Markdown w dokumentowaniu funkcji, by łatwiej było czytać ją w IEx lub ExDoc.
 
 ```elixir
 defmodule Greeter do
@@ -275,13 +306,13 @@ defmodule Greeter do
   """
 
   @doc """
-  Prints a hello message
+  Wyświetla wiadomość powitalną.
 
-  ## Parameters
+  ## Parametry
 
-    - name: String that represents the name of the person.
+    - name: Łańcuch znaków reprezentujący imię osoby.
 
-  ## Examples
+  ## Przykłady
 
       iex> Greeter.hello("Sean")
       "Hello, Sean"
@@ -297,6 +328,8 @@ defmodule Greeter do
 end
 ```
 
- - Podawaj przykłady w dokumentacji. Pozwoli to też na wygenerowanie testów automatycznych na ich podstawie z użyciem [ExUnit.DocTest][]. By to zrobić, należy wywołać makro `doctest/1`, lecz dokumentacja musi spełniać pewne warunki opisane w [oficjalniej dokumentacji][ExUnit.DocTest] narzędzia.
+ - Podawaj przykłady w dokumentacji.
+ Pozwoli to też na wygenerowanie testów automatycznych na ich podstawie z użyciem [ExUnit.DocTest][].
+ By to zrobić, należy wywołać makro `doctest/1`, lecz dokumentacja musi spełniać pewne warunki opisane w [oficjalniej dokumentacji][ExUnit.DocTest] narzędzia.
 
 [ExUnit.DocTest]: https://hexdocs.pm/ex_unit/ExUnit.DocTest.html


### PR DESCRIPTION
1. Polish translation of lesson "Documentation" has been updated.
2. Few fixes to English version:
- `c("greeter.ex")` replaced with `c("greeter.ex", ".")` (`c("greeter.ex")` compiles file without documentation),
- `@spec` added to the rendered documentation – typespec is actually present in the generated documentation (and the lesson mentions it below one of the examples).