### PR TITLE
removes invalid `frameborder` attribute on Youtube iframes.

### DIFF
--- a/_posts/2019-03-18-phoenix-live-view.md
+++ b/_posts/2019-03-18-phoenix-live-view.md
@@ -30,7 +30,7 @@ Let's get LiveView up and running to support a feature that pushes out live upda
 Here's the functionality we're building:
 
 <div class="responsive-embed">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" frameborder="0" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/_posts/2019-04-11-live-view-with-pub-sub.md
+++ b/_posts/2019-04-11-live-view-with-pub-sub.md
@@ -13,7 +13,7 @@ excerpt: >
 In an [earlier post](https://elixirschool.com/blog/phoenix-live-view/), we used the brand new (still pre-release at time of writing) Phoenix LiveView library to build a real-time feature with very little backend code and even less JavaScript. LiveView allowed us to easily connect our client to the server via a socket and push updates down to our client. In an app that allows users to "deploy" a repo to GitHub, we achieved the following real-time functionality:
 
 <div class="responsive-embed">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" frameborder="0" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/8M-Hjj7IBu8" allowfullscreen></iframe>
 </div>
 <br />
 
@@ -22,7 +22,7 @@ But what happens when we have a set of clients that _all_ need to see the _same_
 In this post, we'll learn how to use PubSub to make real-time updates available to all of our LiveView clients, not just the person who clicked the "Deploy to GitHub" button. Our finished product will look like this:
 
 <div class="responsive-embed">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/QLwfYNgVuu0" frameborder="0" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/QLwfYNgVuu0" allowfullscreen></iframe>
 </div>
 <br />
 

--- a/_posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
+++ b/_posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
@@ -22,7 +22,7 @@ Users need to be able to sort this table by cohort name, campus, start date or s
 
 Here's a look at the behavior we're going for. Note how the URL changes when we click on a given column heading to sort the table.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/-4VRaX1uEhk" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/-4VRaX1uEhk" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Using `live_link/2`
 

--- a/_posts/2019-12-29-live-view-live-component.md
+++ b/_posts/2019-12-29-live-view-live-component.md
@@ -138,7 +138,7 @@ end
 
 Maintaining a representation of the search form's selected query and inputed value in state allows us to ensure that the correct search query radio button is selected and allows us to update the placeholder text of the search form input field:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/6Ta2Au-PcQI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/6Ta2Au-PcQI" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 Maintaining the search form state also ensures that users can navigate directly to the `/consumed_messages` route with a set of query params and see not just the correctly populated messages but also the correctly configured search form:


### PR DESCRIPTION
The `frameborder` attribute is not a valid `iframe` attribute and it's not making a visual difference in the site (we could use CSS if needed), let's remove it.

Found in https://rocketvalidator.com/s/328d31c1-0a28-423f-88dc-64c5c0d97590/i/112975746