### PR TITLE
Fix missing title in blog post

### DIFF
--- a/posts/2018-10-23-umbrellas-just-when-it-rains.md
+++ b/posts/2018-10-23-umbrellas-just-when-it-rains.md
@@ -3,7 +3,7 @@
   author_link: "https://github.com/doomspork",
   date: ~D[2018-10-22],
   tags: ["umbrellas", "software design"],
-  title: "",
+  title: "Umbrellas just when it rains",
   excerpt: """
   A look at umbrella applications and how they can help us write cleaner maintainable code.
   """


### PR DESCRIPTION
RV caught an empty h1, due to an empty title in this post

https://rocketvalidator.com/s/624562a6-bdbe-4411-9c28-3652a4887982/p/4681104/i?search=Empty+heading.&non_doc=false