### PR TITLE
Update changeset validation notes

### DIFF
--- a/en/lessons/ecto/changesets.md
+++ b/en/lessons/ecto/changesets.md
@@ -121,7 +121,7 @@ Now we can ensure that `name` is always present:
 ```elixir
 def changeset(struct, params) do
   struct
-  |> cast(params, [:name])
+  |> cast(params, [:name, :age])
   |> validate_required([:name])
 end
 ```


### PR DESCRIPTION
Adding the atom `:age` to the code example making it easier to follow that it's talking about the same changeset made above, not creating a second changeset for validation.