### PR TITLE
Fix Image Template Links in Posts

### DIFF
--- a/posts/2019-01-03-elixir-kaffe-codealong.md
+++ b/posts/2019-01-03-elixir-kaffe-codealong.md
@@ -29,7 +29,7 @@ Say we want to keep an activity log for users. Every time a user triggers an eve
 
 Here's a basic idea of how this might look:
 
-![Kafka Flow Example]({% asset kafka-flow-example.png @path %})
+![Kafka Flow Example](/images/kafka-flow-example.png)
 
 The three services reading from Kafka would only take the pieces of data that they require. For example, the first service would only read from the `banner_click` topic while the last only from `search_term`. The second service that cares about active users might read from both topics to capture all site activity.
 

--- a/posts/2019-05-06-live-view-with-presence.md
+++ b/posts/2019-05-06-live-view-with-presence.md
@@ -94,7 +94,7 @@ After mounting and setting the socket state, the live view will render the `Chat
 
 Our template is simple: it grabs the chat we assigned to our live view's socket, displays the chat room name and iterates over the messages to show us the content and sender. It also contains a form for a new message, built on the empty message changeset we assigned to our socket. At this point, our rendered template looks something like this:
 
-![]({% asset live-view-1.png @path %})
+![live view chat window](/images/live-view-1.png)
 
 ### Pushing Messages to the LiveView Client
 
@@ -181,7 +181,7 @@ The live view handles the `"message"` message by updating the socket's state wit
 
 Now that our live view is smart enough to broadcast messages to all of the users in the given chat room, we're ready to build some features that track and interact with those users. Let's say we want to have our template render a list of users in the chat room, something like this:
 
-![]({% asset live-view-presence-1.png @path %})
+![list users in the chat room](/images/live-view-presence-1.png)
 
 We could create our own data structure for tracking user presence in a live view, store it in the live view's socket, and hand-roll our own functions to update that data structure when a user joins, leaves or otherwise changes their state. However, the [Phoenix Presence behaviour](https://hexdocs.pm/phoenix/Phoenix.Presence.html) abstracts this work away from us. It provides presence tracking for processes and channels, leveraging Phoenix PubSub behind the scenes to broadcast updates. It also uses a CRDT (Conflict-free Replicated Data Type) model, which means it works on distributed applications.
 
@@ -454,7 +454,7 @@ So, we don't have to write any additional code to handle the "leave" event at al
 
 So far, we've leveraged presence to keep track of users as they join or leave the LiveView. We can also use presence to track the state of a given user while they are present in the LiveView process. Let's see how this works by building a feature that indicates that a given user is typing into the new chat message form by appending a `"..."` to their name on the list of present users rendered in the template:
 
-![]({% asset live-view-presence-2.png @path %})
+![show which users are typing](/images/live-view-presence-2.png)
 
 First, we'll update the `:metas` payload we use to describe the starting state of a given user with the data point: `typing: false`:
 

--- a/posts/2019-06-04-live-view-with-channels.md
+++ b/posts/2019-06-04-live-view-with-channels.md
@@ -21,7 +21,7 @@ But then we ran into a blocker.
 
 When new chat messages were appended to the chat window, they appeared *just* out of frame.
 
-![chat message not visible]({% asset chat-message-not-visible.png @path %})
+![chat message not visible](/images/chat-message-not-visible.png)
 
 ---
 
@@ -93,15 +93,15 @@ In order to guarantee that the live view process can send a message to the right
 
 Here's a closer look at how this procedure works:
 
-![live view mounts and renders]({% asset live-view-mount-render.png @path %})
+![live view mounts and renders](/images/live-view-mount-render.png)
 
 ---
 
-![live view socket connects]({% asset live-view-socket-connect.png @path %})
+![live view socket connects](/images/live-view-socket-connect.png)
 
 ---
 
-![live view channel joins]({% asset live-view-channel-join.png @path %})
+![live view channel joins](/images/live-view-channel-join.png)
 
 ---
 
@@ -223,15 +223,15 @@ In this section, we'll dive into the following portion of the process:
 
 Here's a closer look at this flow:
 
-![live view handles event]({% asset live-view-handle-event.png @path %})
+![live view handles event](/images/live-view-handle-event.png)
 
 ---
 
-![live view broadcasts event]({% asset live-view-broadcasts-event.png @path %})
+![live view broadcasts event](/images/live-view-broadcasts-event.png)
 
 ---
 
-![live view sends message to self]({% asset live-view-send-self.png @path %})
+![live view sends message to self](/images/live-view-send-self.png)
 
 ---
 
@@ -300,15 +300,15 @@ Here's the code flow we're aiming for:
 2. The channel's socket is connected with this token; the socket stores it in state.
 3. The channel is joined; it takes the session UUID from its socket's state and registers its PID under a key of that UUID.
 
-![live view mounts with session uuid]({% asset live-view-mount-session-uuid.png @path %})
+![live view mounts with session uuid](/images/live-view-mount-session-uuid.png)
 
 ---
 
-![live view channel connects]({% asset live-view-connect-channel.png @path %})
+![live view channel connects](/images/live-view-connect-channel.png)
 
 ---
 
-![live view channel register]({% asset live-view-channel-register.png @path %})
+![live view channel register](/images/live-view-channel-register.png)
 
 ---
 
@@ -317,7 +317,7 @@ Later...
 4. When the user submits a new chat message, the LiveView processes that received the message broadcast will look up the channel PID under the session UUID in the registry
 5. Each live view will then send the message to the PID they looked up
 
-![live view looks up channel]({% asset live-view-lookup-send-to-channel.png @path %})
+![live view looks up channel](/images/live-view-lookup-send-to-channel.png)
 
 ---
 
@@ -486,10 +486,10 @@ In this section, we'll focus on the following portion of our process:
 
 Here's a closer look:
 
-![live view channel push]({% asset live-view-channel-push.png @path %})
+![live view channel push](/images/live-view-channel-push.png)
 
 ---
-![live view front end update]({% asset live-view-front-end-update.png @path %})
+![live view front end update](/images/live-view-front-end-update.png)
 
 ---
 

--- a/posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
+++ b/posts/2019-10-20-sorting-a-table-with-live-view-live-links.md
@@ -17,7 +17,7 @@ LiveView makes it easy to solve for some of the most common UI challenges with l
 
 Our view presents a table of student cohorts that looks like this:
 
-![live view table]({% asset live-view-table.png @path %})
+![live view table](/images/live-view-table.png)
 
 Users need to be able to sort this table by cohort name, campus, start date or status. We'd also like to ensure that the "sort by" attribute is included in the URL's query params, so that users can share links to sorted views.
 

--- a/posts/2019-12-29-live-view-live-component.md
+++ b/posts/2019-12-29-live-view-live-component.md
@@ -36,7 +36,7 @@ Let's take a look at how we can use components to refactor some complicated Live
 Let's say we have an application that uses a message broker like RabbitMQ to publish and consume messages between systems. Our app persists these messages in the DB and exposes a UI for users to list and search such persisted messages.
 
 
-![live view messages index]({% asset live-view-messages-index.png @path %})
+![live view messages index](/images/live-view-messages-index.png)
 
 We're using LiveView to enact the search functionality, pagination and maintain which messages are currently being displayed in state. Our live view module responds to search form events and maintains the state of the search form, handles the search form submission *and* renders the template with various search and pagination params.
 
@@ -145,7 +145,7 @@ Maintaining a representation of the search form's selected query and inputed val
 Maintaining the search form state also ensures that users can navigate directly to the `/consumed_messages` route with a set of query params and see not just the correctly populated messages but also the correctly configured search form:
 
 
-![live component search form query params]({% asset live-component-search-form-query-params.png @path %})
+![live component search form query params](/images/live-component-search-form-query-params.png)
 
 ### The Problem
 

--- a/posts/2020-04-24-instrumenting-phoenix-with-live-dashboard.md
+++ b/posts/2020-04-24-instrumenting-phoenix-with-live-dashboard.md
@@ -72,7 +72,7 @@ And that's it! If we run `mix deps.get` and then `mix phx.server`, we'll see our
 
 ### Home
 
-![live dashboard home]({% asset ld-home.png @path %})
+![live dashboard home](/images/ld-home.png)
 
 There are a number of monitoring features that LiveView displays for us out-of-the-box.
 
@@ -80,31 +80,31 @@ On the `Home` page, we can see system information like our Erlang/OTP version, P
 
 ### Processes
 
-![live dashboard processes]({% asset ld-processes.png @path %})
+![live dashboard processes](/images/ld-processes.png)
 
 The `Processes` page allows us to introspect on the processes running in our app. We can see helpful info like how much memory each process account for and even which function a given process is currently executing. Inspecting a given process, we see further info including its status, initial function and stacktrace.
 
 ### Ports
 
-![live dashboard ports]({% asset ld-ports.png @path %})
+![live dashboard ports](/images/ld-ports.png)
 
 The `Ports` page visualizes the ports (responsible for application I/O) exposed by our application.
 
 Inspecting a given port, we can see the which process is responsible for exposing the port and managing input/output over that port.
 
-![live dashboard port-detail]({% asset ld-port-detail.png @path %})
+![live dashboard port-detail](/images/ld-port-detail.png)
 
 ### Sockets
 
 The `Sockets` page exposes information about all of the sockets currently managed by the application. Sockets in our Phoenix app are responsible for all UDP/TCP traffic. Here, we even see the socket connection responsible for listening on port `:4000`.
 
-![live dashboard port-4000-detail]({% asset ld-port-4000-detail.png @path %})
+![live dashboard port-4000-detail](/images/ld-port-4000-detail.png)
 
 ### ETS
 
 The last out-of-the-box page that the LiveDashboard offers us is the `ETS` page. ETS (Erlang Term Storage) is our in-memory storage. We can even se the entry for the Telemetry handler table.
 
-![live dashboard ets-detail]({% asset ld-ets-detail.png @path %})
+![live dashboard ets-detail](/images/ld-ets-detail.png)
 
 ## LiveDashboard Metrics
 ### Establishing Metrics
@@ -208,7 +208,7 @@ live_dashboard "/dashboard", metrics: Quantum.Telemetry
 
 Now, if we visit `/dashboard` in the browser and click the `Metrics` tab we'll see our metrics:
 
-![live dashboard metrics]({% asset ld-metrics.png @path %})
+![live dashboard metrics](/images/ld-metrics.png)
 
 Let's take a peek under the hood to better understand how this configuration works.
 
@@ -305,7 +305,7 @@ plug Phoenix.LiveDashboard.RequestLogger,
 
 Now we can visit `/dashboard` in the browser and click the `Request Logger` tab. We'll click "enable cookie" to enable a cookie that streams request logs. Now we should see the stream of our request logs:
 
-![live dashboard request-logger]({% asset ld-request-logger.png @path %})
+![live dashboard request-logger](/images/ld-request-logger.png)
 
 Let's take a brief look under the hood of LiveDashboard to get a better understanding of how RequestLogger works.
 

--- a/posts/2020-10-06-server-side-svg-charts-with-contex-and-liveview.md
+++ b/posts/2020-10-06-server-side-svg-charts-with-contex-and-liveview.md
@@ -33,7 +33,7 @@ In this post, we'll focus on using Contex to build a bar chart.
 ## What We'll Build
 Drawing from an example that you'll see in greater depth in our upcoming LiveView book, we'll add a chart to our Admin Dashboard LiveView. The Admin Dashboard is part of an online gaming app in which users can play online versions of games like ping-pong and tic-tac-toe. We ask users to fill our a survey that rates games on a scale of 1 to 5 stars. Our Admin Dashboard should include a chart of products and their average star ratings. Something like this:
 
-![game ratings chart]({% asset game-ratings-chart.png @path %})
+![game ratings chart](/images/game-ratings-chart.png)
 
 The chart should also update in real-time. In other words, as users around the world use and review our extremely popular and super fun games, the chart should update in real-time to reflect updated average ratings.
 
@@ -418,7 +418,7 @@ Our `GameRatingsLive` template is pretty simple, it renders the SVG stored in th
 
 Now, we should see the following chart rendered when we navigate to `/admin-dashboard`:
 
-![game ratings chart]({% asset game-ratings-chart.png @path %})
+![game ratings chart](/images/game-ratings-chart.png)
 
 One "gotcha" that I'll point out is that, in order to get the column labels (i.e. game names and star values) to be visible, I had to apply the custom CSS borrowed from the Contex example app [here](https://github.com/mindok/contex-samples/blob/master/assets/css/app.css#L6-L52), and copied below:
 
@@ -487,7 +487,7 @@ We'll use this function to implement the following functionality:
 
 Something like this:
 
-![game ratings chart selected category]({% asset game-ratings-bar-chart-selected.png @path %})
+![game ratings chart selected category](/images/game-ratings-bar-chart-selected.png)
 
 We'll begin by using the `BarChart.event_handler/2` function to add a `phx-click` event to the bars in our chart.
 


### PR DESCRIPTION
# Overview

Closes https://github.com/elixirschool/school_house/issues/145 .

Some of the old jekyll template tags for images were leftover. This pr updates those links.