### PR TITLE
[PL] Update translation: "Erlang Interoperability" (+ minor change in EN version)

### DIFF
--- a/lessons/en/intermediate/erlang.md
+++ b/lessons/en/intermediate/erlang.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.0.2",
+  version: "1.0.3",
   title: "Erlang Interoperability",
   excerpt: """
   One of the added benefits to building on top of the Erlang VM (BEAM) is the plethora of existing libraries available to us.
@@ -156,4 +156,4 @@ Erlang:
 20
 ```
 
-That's it!  Leveraging Erlang from within our Elixir applications is easy and effectively doubles the number of libraries available to us.
+That's it! Leveraging Erlang from within our Elixir applications is easy and effectively doubles the number of libraries available to us.

--- a/lessons/pl/intermediate/erlang.md
+++ b/lessons/pl/intermediate/erlang.md
@@ -1,17 +1,20 @@
 %{
-  version: "0.9.1",
+  version: "1.0.3",
   title: "Współpraca z Erlangiem",
   excerpt: """
-  Jedną z zalet działania w ramach maszyny wirtualnej Erlanga jest bogactwo istniejących rozwiązań. Interoperacyjność pozwala nam na wykorzystanie tych rozwiązań, jak i standardowej biblioteki Erlanga w naszym Elixirowym kodzie. W tej lekcji przyjrzymy się, jak możemy łączyć nasz kod z bibliotekami stworzonymi w Erlangu.
+  Jedną z zalet działania w ramach maszyny wirtualnej Erlanga (BEAM) jest bogactwo istniejących bibliotek, których możemy użyć.
+  Interoperacyjność pozwala nam na wykorzystanie tych rozwiązań oraz standardowej biblioteki Erlanga w naszym elixirowym kodzie.
+  W tej lekcji przyjrzymy się, jak możemy łączyć nasz kod z bibliotekami stworzonymi w Erlangu.
   """
 }
 ---
 
 ## Biblioteka standardowa
 
-Do kodu napisanego w Erlangu możemy odwołać się w dowolnym miejscu naszego kodu. Moduły Erlanga są reprezentowane przez atomy, pisane małymi literami, na przykład `:os` czy `:timer`.
+Obszerna biblioteka standardowa Erlanga może być użyta w dowolnym miejscu elixirowego kodu w naszej aplikacji.
+Moduły Erlanga są reprezentowane przez atomy, pisane małymi literami, na przykład `:os` czy `:timer`.
 
-Użyjmy `:timer.tc` by zmierzyć czas wykonania funkcji:
+Użyjmy `:timer.tc`, by zmierzyć czas wykonania funkcji:
 
 ```elixir
 defmodule Example do
@@ -27,12 +30,13 @@ Time: 8 μs
 Result: 1000000
 ```
 
-Pełna lista modułów jest dostępna w podręczniku [Erlang Reference Manual](http://erlang.org/doc/apps/stdlib/).
+Pełna lista modułów jest dostępna w tym miejscu: [Erlang Reference Manual](http://erlang.org/doc/apps/stdlib/).
 
 ## Pakiety Erlanga
 
-W jednej z poprzednich lekcji poznaliśmy narzędzie Mix służące do zarządzania zależnościami. Dodawanie zależności do bibliotek Erlangowych działa w taki sam sposób. Jedyny wyjątek stanowi to, że biblioteki Erlanga nie są opublikowane w [Hex](https://hex.pm), ale można się do nich odwołać podając nazwę repozytorium na githubie:
-
+W jednej z poprzednich lekcji poznaliśmy narzędzie Mix, służące do zarządzania zależnościami.
+Dodawanie zależności do bibliotek erlangowych działa w taki sam sposób.
+Jedyny wyjątek stanowi to, że biblioteki Erlanga nie są opublikowane w [Hex](https://hex.pm), ale można się do nich odwołać poprzez odnośnik do repozytorium gita:
 
 ```elixir
 def deps do
@@ -40,7 +44,7 @@ def deps do
 end
 ```
 
-I teraz mamy dostęp do biblioteki napisanej w erlangu:
+Teraz możemy użyć naszej erlangowej biblioteki:
 
 ```elixir
 png =
@@ -49,11 +53,12 @@ png =
 
 ## Najważniejsze różnice 
 
-Jak już wiemy jak korzystać z Erlanga musimy jeszcze poznać pewne pułapki wynikające z tego rozwiązania.
+Skoro wiemy już, jak korzystać z Erlanga, musimy jeszcze poznać pewne pułapki wynikające z tego rozwiązania.
 
 ### Atomy
 
-Atomy w Erlangu wyglądają bardzo podobnie do tych z Elixira. Nie zawierają dwukropka (`:`), są pisane małymi literami i można w nich użyć znaku podkreślenia:
+Atomy w Erlangu wyglądają bardzo podobnie do tych z Elixira, jednak nie mają dwukropka z przodu (`:`).
+Są pisane małymi literami i można w nich użyć znaku podkreślenia:
 
 Elixir:
 
@@ -69,7 +74,8 @@ example.
 
 ### Ciągi znaków
 
-W Elixirze, gdy mówimy o ciągach znaków mamy na myśli dane bitowe interpretowane jako UTF-8. W Erlangu ciągi znaków też używają cudzysłowów, ale są listami znaków:
+Gdy mówimy o ciągach znaków w Elixirze, mamy na myśli dane bitowe interpretowane jako UTF-8.
+W Erlangu ciągi znaków też używają cudzysłowów, ale są listami znaków:
 
 Elixir:
 
@@ -97,7 +103,8 @@ false
 true
 ```
 
-Musimy pamiętać, że wiele starszych bibliotek Erlanga, nie wspiera formy binarnej i musimy zamienić ciągi znaków z Elixira na listy.  Na całe szczęście mamy do tego odpowiednią funkcję `to_charlist/1`:
+Musimy pamiętać, że wiele starszych bibliotek Erlanga nie wspiera formy binarnej i musimy zamienić ciągi znaków z Elixira na listy.
+Na szczęście mamy do tego odpowiednią funkcję `to_charlist/1`:
 
 ```elixir
 iex> :string.words("Hello World")
@@ -115,11 +122,13 @@ iex> :string.words("Hello World")
     (stdlib) string.erl:1659: :string.strip/3
     (stdlib) string.erl:1597: :string.words/2
 
-iex> "Hello World" |> to_charlist |> :string.words
+iex> "Hello World" |> to_charlist() |> :string.words
 2
 ```
 
 ### Zmienne
+
+W Erlangu nazwy zmiennych rozpoczynają się wielką literą, a przypisywanie nowych wartości do istniejących już zmiennych nie jest dozwolone.
 
 Elixir:
 
@@ -127,8 +136,11 @@ Elixir:
 iex> x = 10
 10
 
-iex> x1 = x + 10
+iex> x = 20
 20
+
+iex> x1 = x + 10
+30
 ```
 
 Erlang:
@@ -137,8 +149,11 @@ Erlang:
 1> X = 10.
 10
 
-2> X1 = X + 1.
-11
+2> X = 20.
+** exception error: no match of right hand side value 20
+
+3> X1 = X + 10.
+20
 ```
 
-I to wszystko! Możliwość wykorzystania Erlanga z kodu aplikacji pisanych w Elixirze jest proste i efektywnie zwiększa ilość bibliotek, które możemy wykorzystać.
+I to wszystko! Możliwość wykorzystania Erlanga w kodzie aplikacji pisanych w Elixirze jest proste i istotnie zwiększa liczbę bibliotek, z których możemy korzystać.


### PR DESCRIPTION
1. Updated Polish translation of the lesson "Erlang Interoperability".
2. Removed redundant space in the English version.