### PR TITLE
Update Elixir Book Club Post Author Image

### DIFF
--- a/posts/2021-07-14-elixir-book-club.md
+++ b/posts/2021-07-14-elixir-book-club.md
@@ -1,6 +1,6 @@
 %{
   author: "Frank Kumro",
-  author_link: "https://frank.kumro.io",
+  author_link: "https://github.com/fkumro",
   date: ~D[2021-07-14],
   tags: ["Announcement"],
   title: "Learning Elixir with others - The Elixir Book Club",


### PR DESCRIPTION
# Overview
Updated the author link URL in the Elixir Book Club blog post to use the GitHub profile rather than personal site so the author image loads successfully.

### Screenshots
#### Before
<img width="669" alt="Screen Shot 2021-10-03 at 10 26 09 AM" src="https://user-images.githubusercontent.com/1526888/135762917-a38233f6-d4a7-4907-ba65-161d06d7ebd6.png">

#### After
<img width="618" alt="Screen Shot 2021-10-03 at 10 27 03 AM" src="https://user-images.githubusercontent.com/1526888/135762951-48dcef00-cb7b-4c9c-9762-3c3a9eaba647.png">

