### PR TITLE
Add Title Back to Umbrella Apps Blog Post

### DIFF
--- a/posts/2018-10-23-umbrellas-just-when-it-rains.md
+++ b/posts/2018-10-23-umbrellas-just-when-it-rains.md
@@ -3,7 +3,7 @@
   author_link: "https://github.com/doomspork",
   date: ~D[2018-10-22],
   tags: ["umbrellas", "software design"],
-  title: "",
+  title: "Umbrellas: Only When it Rains?",
   excerpt: """
   A look at umbrella applications and how they can help us write cleaner maintainable code.
   """


### PR DESCRIPTION
# Overview

This should resolve https://github.com/elixirschool/elixirschool/issues/2712 and hopefully https://github.com/elixirschool/school_house/issues/77 as well!

It looks like the title of this blog post was lost in the content shuffle. [Here is a reference](https://github.com/elixirschool/elixirschool/blob/45b80cdc97b04f39770b7cc3ae51bf36e6c66053/_posts/2018-10-23-umbrellas-just-when-it-rains.md) to a previous version of the blog post where I grabbed the title from.