### PR TITLE
Remove unnecessary `raw` tags in ETS.md

### DIFF
--- a/lessons/en/storage/ets.md
+++ b/lessons/en/storage/ets.md
@@ -159,7 +159,7 @@ iex> :ets.match_object(:user_lookup, {:"$1", :_, :"$3"})
 [{"doomspork", "Sean", ["Elixir", "Ruby", "Java"]},
  {"3100", "", ["Elixir", "Ruby", "JavaScript"]}]
 
-{% raw %}iex> :ets.select(:user_lookup, [{{:"$1", :_, :"$3"}, [], [:"$_"]}]){% endraw %}
+iex> :ets.select(:user_lookup, [{{:"$1", :_, :"$3"}, [], [:"$_"]}])
 [{"doomspork", "Sean", ["Elixir", "Ruby", "Java"]},
  {"3100", "", ["Elixir", "Ruby", "JavaScript"]}]
 ```


### PR DESCRIPTION
The `raw` and `endraw` tags are showing up in outputted HTML

![Screen Shot 2022-01-24 at 12 12 26 PM](https://user-images.githubusercontent.com/691365/150831153-ae6800ff-8f48-465a-a522-39c33839b251.png)

Since none of the other examples include this escaping, I am assuming it's unnecessary. 