### PR TITLE
Update collections.md

### DIFF
--- a/lessons/es/basics/collections.md
+++ b/lessons/es/basics/collections.md
@@ -16,7 +16,7 @@ iex> [3.14, :pie, "Apple"]
 [3.14, :pie, "Apple"]
 ```
 
-Elixir implementa las colecciones como listas enlazadas.
+Elixir implementa a las colecciones de lista como listas enlazadas.
 Esto significa que acceder al largo de la lista es una operación que se ejecutará en tiempo lineal (`O(n)`).
 Por esta razón, normalmente es más rápido agregar un elemento al inicio que al final:
 


### PR DESCRIPTION
on the current translation the word list as in "list collections" went missing, so it was unclear which collections were implied.
en la traducción actual, se perdió la palabra lista de la expresión "list collections" de manera que no era claro a que colecciones se refería.