### PR TITLE
[PT] Remove newline in IEx Helpers lesson

### DIFF
--- a/lessons/pt/basics/iex_helpers.md
+++ b/lessons/pt/basics/iex_helpers.md
@@ -2,7 +2,6 @@
   version: "1.0.2",
   title: "IEx Helpers",
   excerpt: """
-  
   """
 }
 ---


### PR DESCRIPTION
This newline was causing "excerpt" to be showed in the lesson page.

Before:
![image](https://user-images.githubusercontent.com/34754632/159622272-05682a3c-d5eb-42db-95ae-c7dcf9d89ca5.png)

After:
![image](https://user-images.githubusercontent.com/34754632/159622337-7bf68b4b-5336-47e5-8630-118e5012e463.png)
