### PR TITLE
Updated collections.md to avoid confusing usage of verb "accessing"

### DIFF
--- a/lessons/en/basics/collections.md
+++ b/lessons/en/basics/collections.md
@@ -176,7 +176,7 @@ iex> %{foo: "bar", hello: "world"} == %{:foo => "bar", :hello => "world"}
 true
 ```
 
-In addition, there is a special syntax for accessing atom keys:
+In addition, there is a special syntax you can use with atom keys:
 
 ```elixir
 iex> map = %{foo: "bar", hello: "world"}


### PR DESCRIPTION
When talking about key value pairs the verb "accessing" generally means accessing the value with the key. It caused me some confusion when I read it. I have removed this word, to avoid this confusion, and replaced it with plain easy to read english.