### PR TITLE
Fix Elixir Version Used in CI to Match School House

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: mv content/images assets/static/images
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24
-          elixir-version: 1.12
+          otp-version: 25
+          elixir-version: 1.13.4
       - run: mix deps.get
       - run: mix compile


### PR DESCRIPTION
# Overview

Right now CI actions are failing because the [`school_house`](https://github.com/elixirschool/school_house) project uses version 1.13 of Elixir but CI is configured on this project to use 1.12. 

Example CI failure: https://github.com/elixirschool/elixirschool/runs/6740912572?check_suite_focus=true