### PR TITLE
Fix deploy_content action

### DIFF
--- a/.github/workflows/deploy_content.yml
+++ b/.github/workflows/deploy_content.yml
@@ -15,4 +15,4 @@ jobs:
           -H "Authorization: Bearer ${{secrets.PAT_TOKEN}}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/elixirschool/school_house/actions/workflows/deploy.yml/dispatches \
-          -d '{"ref": "master"}'
+          -d '{"ref": "main"}'


### PR DESCRIPTION
This PR updates the deploy_content action to target the correct `main` branch of the `elixirschool/school_house` repo. It was targeting the `master` branch which does not exist.