### PR TITLE
Fix options to match current cURL version

### DIFF
--- a/.github/workflows/deploy_content.yml
+++ b/.github/workflows/deploy_content.yml
@@ -16,4 +16,4 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/elixirschool/school_house/actions/workflows/deploy.yml/dispatches \
           -d '{"ref": "main"}' \
-          --fail-with-body
+          --fail


### PR DESCRIPTION
The version of cURL found in the GitHub runner doesn't support `--fail-with-body` so we should use `--fail` instead.