### PR TITLE
[PL] Update translation of lesson "Enum" (+ minor change in EN)

### DIFF
--- a/lessons/en/basics/enum.md
+++ b/lessons/en/basics/enum.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.9.0",
+  version: "1.9.1",
   title: "Enum",
   excerpt: """
   A set of algorithms for enumerating over enumerables.
@@ -223,6 +223,7 @@ iex> Enum.uniq_by([%{x: 1, y: 1}, %{x: 2, y: 1}, %{x: 3, y: 3}], fn coord -> coo
 ```
 
 # Enum using the Capture operator (&)
+
 Many functions within the Enum module in Elixir take anonymous functions as an argument to work with each iterable of the enumerable that is passed.
 
 These anonymous functions are often written shorthand using the Capture operator (&).
@@ -255,6 +256,7 @@ iex> Enum.map([1,2,3], plus_three)
 ```
 
 ## Using the capture operator with a named function
+
 First we create a named function and call it within the anonymous function defined in `Enum.map/2`.
 
 ```elixir

--- a/lessons/pl/basics/enum.md
+++ b/lessons/pl/basics/enum.md
@@ -1,19 +1,19 @@
 %{
-  version: "1.8.0",
+  version: "1.9.1",
   title: "Enum",
   excerpt: """
-  Algorytmy pomagające przetwarzać kolekcje.
+  Zbiór algorytmów służących do przetwarzania kolekcji wyliczeniowych.
   """
 }
 ---
 
-## Enum
+## Wstęp
 
 Moduł `Enum` zawiera ponad siedemdziesiąt funkcji wspomagających pracę z kolekcjami.
-Wszystkie kolekcje, o których dowiedzieliśmy się w [poprzedniej lekcji](/pl/lessons/basics/collections), z wyjątkiem krotek, są przeliczalne.
+Wszystkie kolekcje, o których dowiedzieliśmy się w [poprzedniej lekcji](/pl/lessons/basics/collections), z wyjątkiem krotek, należą do wyliczeniowego typu danych (ang. _enumerables_).
 
-W tej lekcji przyjrzymy się tylko niektórym z funkcji.
-Innym sposobem na zapoznanie się z dostępnymi funkcjami jest wykorzystanie `iex`:
+W tej lekcji omówiony będzie jedynie podzbiór dostępnych funkcji, jednak możemy zbadać je samodzielnie.
+Przeprowadźmy mały eksperyment w IEx.
 
 ```elixir
 iex> Enum.__info__(:functions) |> Enum.each(fn({function, arity}) ->
@@ -28,15 +28,14 @@ at/3
 ...
 ```
 
-Mamy do dyspozycji ogromną ilość funkcji.
-Nie bez powodu.
-Programowanie funkcyjne opiera się na przetwarzaniu różnego rodzaju kolekcji.
-W połączeniu z innymi funkcjonalnościami Elixira, jako programiści otrzymujemy bardzo efektywne narzędzia.
+Mamy do dyspozycji ogromną liczbę funkcji – nie bez powodu.
+Przetwarzanie różnego rodzaju kolekcji jest podstawą programowania funkcyjnego — w połączeniu z innymi instrumentami Elixira może to stanowić naprawdę niesamowicie potężne narzędzie w rękach programistów.
 
-Pełna lista jest dostępna w dokumentacji modułu [`Enum`](https://hexdocs.pm/elixir/Enum.html).
-Do leniwego przetwarzania kolekcji służy moduł [`Stream`](https://hexdocs.pm/elixir/Stream.html).
+# Podstawowe funkcje
 
-### all?
+Pełna lista funkcji jest dostępna w dokumentacji modułu [`Enum`](https://hexdocs.pm/elixir/Enum.html); do leniwego przetwarzania kolekcji służy moduł [`Stream`](https://hexdocs.pm/elixir/Stream.html).
+
+## all?
 
 Gdy chcemy użyć funkcji `all?`, jak i wielu innych z modułu `Enum`, musimy jako parametr przekazać funkcję, którą wywołamy na elementach kolekcji.
 Funkcja `all?` zwróci `true`, jeżeli dla wszystkich elementów nasza funkcja zwróci prawdę, w przeciwnym wypadku otrzymamy `false`:
@@ -48,33 +47,30 @@ iex> Enum.all?(["foo", "bar", "hello"], fn(s) -> String.length(s) > 1 end)
 true
 ```
 
-### any?
+## any?
 
-W przeciwieństwie do poprzedniej funkcja `any?` zwróci `true`, jeżeli choć dla jednego elementu nasza funkcja zwróci `true`:
+W odróżnieniu od poprzedniej, funkcja `any?` zwróci `true`, jeżeli choć dla jednego elementu przekazana funkcja zwróci `true`:
 
 ```elixir
 iex> Enum.any?(["foo", "bar", "hello"], fn(s) -> String.length(s) == 5 end)
 true
 ```
 
-### chunk_every
+## chunk_every
 
-Jeżeli chcesz podzielić kolekcję na mniejsze grupy to `chunk_every/2` jest funkcją, której zapewne szukasz:
+Jeżeli chcesz podzielić kolekcję na mniejsze grupy, `chunk_every/2` jest funkcją, której prawdopodobnie szukasz:
 
 ```elixir
 iex> Enum.chunk_every([1, 2, 3, 4, 5, 6], 2)
 [[1, 2], [3, 4], [5, 6]]
 ```
 
-Jest dostępne kilka wersji `chunk_every/4`, ale nie będziemy ich zgłębiać.
-By dowiedzieć się więcej, zajrzyj do [`oficjalnej dokumentacji tej funkcji`](https://hexdocs.pm/elixir/Enum.html#chunk_every/4).
+Jest dostępne kilka wersji `chunk_every/4`, ale nie będziemy ich zgłębiać — aby dowiedzieć się więcej, zajrzyj do [`oficjalnej dokumentacji tej funkcji`](https://hexdocs.pm/elixir/Enum.html#chunk_every/4).
 
-### chunk_by
+## chunk_by
 
 Jeżeli chcemy pogrupować elementy kolekcji na podstawie czegoś innego niż liczność, możemy użyć funkcji `chunk_by/2`.
-Jako argumenty przyjmuje ona kolekcję oraz funkcję.
-Grupy tworzone są na podstawie wyniku działania funkcji.
-Jeżeli wynik zmienia się, to tworzona jest nowa grupa, nawet jeżeli wcześniej istniała grupa dla danego wyniku funkcji.
+Jako argumenty przyjmuje ona kolekcję oraz funkcję, a kiedy wynik zwracany przez tę funkcję zmienia się w stosunku do poprzedniego elementu, tworzona jest kolejna, nowa grupa.
 W poniższych przykładach każdy ciąg o tej samej długości jest grupowany, dopóki nie napotkamy nowego ciągu o nowej długości:
 
 ```elixir
@@ -84,20 +80,20 @@ iex> Enum.chunk_by(["one", "two", "three", "four", "five", "six"], fn(x) -> Stri
 [["one", "two"], ["three"], ["four", "five"], ["six"]]
 ```
 
-### map_every
+## map_every
 
 Czasami grupowanie elementów kolekcji nie jest dokładnie tym, o co nam chodzi.
-W takim przypadku funkcja `map_every/3` pozwoli nam na pracę z konkretnymi elementami kolekcji:
+W takim przypadku funkcja `map_every/3` pozwoli nam na przetworzenie każdego n-tego elementu, poczynając jednak zawsze od pierwszego:
 
 ```elixir
 # Funkcja zostanie wywołana dla co trzeciego elementu
 iex> Enum.map_every([1, 2, 3, 4, 5, 6, 7, 8], 3, fn x -> x + 1000 end)
 [1001, 2, 3, 1004, 5, 6, 1007, 8]
-```  
+```
 
-### each
+## each
 
-Jeżeli chcemy przejść przez kolekcję bez zwracania nowej wartości, to używamy funkcji `each/2`:
+Może być konieczne, aby przejść przez kolekcję bez zwracania nowej wartości — w takim przypadku możemy użyć funkcji `each/2`:
 
 ```elixir
 iex> Enum.each(["one", "two", "three"], fn(s) -> IO.puts(s) end)
@@ -109,16 +105,16 @@ three
 
 __Uwaga__: Funkcja `each/2` zwraca atom `:ok`.
 
-### map
+## map
 
-By wywołać naszą funkcję na każdym elemencie kolekcji i uzyskać nową kolekcję używamy funkcji `map/2`:
+By wywołać naszą funkcję na każdym elemencie kolekcji i uzyskać nową kolekcję, używamy funkcji `map/2`:
 
 ```elixir
 iex> Enum.map([0, 1, 2, 3], fn(x) -> x - 1 end)
 [-1, 0, 1, 2]
 ```
 
-### min
+## min
 
 Funkcja `min/1` znajduje najmniejszą wartość w kolekcji:
 
@@ -131,10 +127,10 @@ Funkcja `min/2` robi dokładnie to samo, ale w przypadku, gdy kolekcja jest pust
 
 ```elixir
 iex> Enum.min([], fn -> :foo end)
-:foo  
+:foo
 ```
 
-### max
+## max
 
 Funkcja `max/1` znajduje największą wartość w kolekcji:
 
@@ -147,10 +143,10 @@ Funkcja `max/2` jest dla `max/1` tym, czym `min/2` jest dla `min/1`:
 
 ```elixir
 iex> Enum.max([], fn -> :bar end)
-:bar  
+:bar
 ```
 
-### filter
+## filter
 
 Funkcja `filter/2` pozwala nam na filtrowanie kolekcji w celu uwzględnienia tylko tych elementów, dla których funkcja anonimowa zwróci wartość `true`.
 
@@ -159,11 +155,10 @@ iex> Enum.filter([1, 2, 3, 4], fn(x) -> rem(x, 2) == 0 end)
 [2, 4]
 ```
 
-### reduce
+## reduce
 
 Funkcja `reduce/3` pozwala na sprowadzenie kolekcji do pojedynczej wartości.
-By tego dokonać, możemy opcjonalnie podać akumulator (przykładowo `10`), by został przekazany do naszej funkcji.
-Jeżeli nie podamy akumulatora, to zostanie zastąpiony przez pierwszy element kolekcji:
+By tego dokonać, możemy opcjonalnie podać akumulator (przykładowo `10`), by został przekazany do naszej funkcji; jeżeli nie podamy akumulatora, to zostanie zastąpiony przez pierwszy element kolekcji:
 
 ```elixir
 iex> Enum.reduce([1, 2, 3], 10, fn(x, acc) -> x + acc end)
@@ -176,7 +171,7 @@ iex> Enum.reduce(["a","b","c"], "1", fn(x,acc)-> x <> acc end)
 "cba1"
 ```
 
-### sort
+## sort
 
 Sortowanie kolekcji jest bardzo proste dzięki nie jednej, a dwóm funkcjom sortowania.
 
@@ -209,7 +204,7 @@ Enum.sort([2, 3, 1], :desc)
 [3, 2, 1]
 ```
 
-### uniq
+## uniq
 
 Jeżeli chcemy usunąć duplikaty z kolekcji, możemy użyć funkcji `uniq/1`:
 
@@ -218,7 +213,7 @@ iex> Enum.uniq([1, 2, 3, 2, 1, 1, 1, 1, 1])
 [1, 2, 3]
 ```
 
-### uniq_by
+## uniq_by
 
 `uniq_by/2` również usuwa duplikaty z kolekcji, jednocześnie umożliwiając przekazanie funkcji, która zostanie wykorzystana do porównania unikalności.
 
@@ -227,16 +222,16 @@ iex> Enum.uniq_by([%{x: 1, y: 1}, %{x: 2, y: 1}, %{x: 3, y: 3}], fn coord -> coo
 [%{x: 1, y: 1}, %{x: 3, y: 3}]
 ```
 
-### Enum przy użyciu operatora przechwytywania (&)
+# Enum przy użyciu operatora przechwytywania (&)
 
-Wiele funkcji w module Enum w Elixir przyjmuje anonimowe funkcje jako argument do pracy z każdym elementem kolekcji.
+Wiele funkcji w module Enum w Elixirze przyjmuje anonimowe funkcje jako argument do pracy z każdym elementem kolekcji.
 
 Te anonimowe funkcje są często zapisywane w skrócie przy użyciu operatora przechwytywania (&).
 
 Oto kilka przykładów, które pokazują, jak operator przechwytywania może zostać wykorzystany do pracy z funkcjami z modułu `Enum`.
 Każda wersja jest funkcjonalnie równoważna.
 
-#### Używanie operatora przechwytywania z funkcją anonimową
+## Używanie operatora przechwytywania z funkcją anonimową
 
 Poniżej znajduje się typowy przykład standardowej składni podczas przekazywania funkcji anonimowej do `Enum.map/2`.
 
@@ -245,7 +240,7 @@ iex> Enum.map([1,2,3], fn number -> number + 3 end)
 [4, 5, 6]
 ```
 
-Teraz wykorzystując operator przechwytywania (&); każda liczba z listy ([1, 2, 3]) zostaje przypisana do zmiennej &1, w momencie, gdy jest ona wykorzystywana przez funkcję mapującą.
+Teraz wykorzystując operator przechwytywania (&); każda liczba z listy ([1, 2, 3]) zostaje przypisana do zmiennej &1 w momencie, gdy jest ona wykorzystywana przez funkcję mapującą.
 
 ```elixir
 iex> Enum.map([1,2,3], &(&1 + 3))
@@ -260,7 +255,7 @@ iex> Enum.map([1,2,3], plus_three)
 [4, 5, 6]
 ```
 
-#### Używanie operatora przechwytywania z funkcją nazwaną
+## Używanie operatora przechwytywania z funkcją nazwaną
 
 Najpierw tworzymy nazwaną funkcję i wywołujemy ją w ramach funkcji anonimowej zdefiniowanej w `Enum.map/2`.
 


### PR DESCRIPTION
1. Polish translation of lesson "Enum" has been updated to reflect the latest EN version (in particular changes from #2766).
2. Added missing newlines after two sub-chapters titles in EN version.