### PR TITLE
logger-changed-to-LoggerExample-and-env-deleted

### DIFF
--- a/lessons/en/advanced/metaprogramming.md
+++ b/lessons/en/advanced/metaprogramming.md
@@ -110,23 +110,26 @@ This is different from other languages where there is still the overhead of a fu
 To demonstrate this we'll make a simple logger that can either be enabled or disabled:
 
 ```elixir
-defmodule Logger do
+defmodule LoggerExample do
   defmacro log(msg) do
-    if Application.get_env(:logger, :enabled) do
+
       quote do
-        IO.puts("Logged message: #{unquote(msg)}")
+        IO.puts("[LOGGER]- #{Time.utc_now()} : #{unquote(msg)}")
       end
-    end
+
   end
 end
 
 defmodule Example do
-  require Logger
+  require LoggerExample
 
-  def test do
-    Logger.log("This is a log message")
+  def test(text \\ "default-message") do
+    LoggerExample.log("#{text}")
   end
 end
+
+
+Example.test("This is new message!")
 ```
 
 With logging enabled our `test` function would result in code looking something like this:


### PR DESCRIPTION
"Logger" module name is not working.  We have to change module name Logger to another because "elixir" already have "Logger" module name in itself.

Error : {"init termiLogger - error: nating in do_boot",{undef,[{'Elixir.Logger',flush,[],[]},{'Elixir.{reKermoved_failing_filter,process_level} nel.CLI',run,1,[{file,"lib/kernel/cli.ex"},{line,64}]},{init,start_em,1,[{file,"init.erl"},{line,1220}]},{init,do_boot,3,[{file,"init.erl"},{line,910}]}]}} init terminating in do_boot ({undef,[{Elixir.Logger,flush,[],[]},{Elixir.Kernel.CLI,run,1,[{_},{_}]},{init,start_em,1,[{_},{_}]},{init,do_boot,3,[{_},{_}]}]})