### PR TITLE
Add missing punctuation in mix.md

### DIFF
--- a/lessons/en/basics/mix.md
+++ b/lessons/en/basics/mix.md
@@ -7,7 +7,7 @@
   It's a crucial part of any Elixir project and in this lesson we're going to explore just a few of its great features.
   To see all that Mix has to offer in the current environment run `mix help`.
 
-Until now we've been working exclusively within `iex` which has limitations
+Until now we've been working exclusively within `iex` which has limitations.
   In order to build something substantial we need to divide our code up into many files to effectively manage it; Mix lets us do that with projects.
   """
 }


### PR DESCRIPTION
In the opening paragraph of the English version of the mix.md file, there was a missing period.