### PR TITLE
Update associations.md to use primary_key: false on migration

### DIFF
--- a/lessons/en/ecto/associations.md
+++ b/lessons/en/ecto/associations.md
@@ -229,7 +229,7 @@ defmodule Friends.Repo.Migrations.CreateMoviesActors do
   use Ecto.Migration
 
   def change do
-    create table(:movies_actors) do
+    create table(:movies_actors, primary_key: false) do
       add :movie_id, references(:movies)
       add :actor_id, references(:actors)
     end


### PR DESCRIPTION
I was following this tutorial, but when trying to populate the associations I kept running into a postgresql error complaining about a `column id not null violation`

I didn't realize what was going on until I looked at the database, and the recommended migration adds an `id` column to the `movies_actors` table, which I was leaving null during the `put_assoc/3` call!

Easy fix here, as other n00bs might run into this.