### PR TITLE
Remove input count from iex example

### DIFF
--- a/lessons/bn/basics/date_time.md
+++ b/lessons/bn/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.1",
+  version: "1.1.2",
   title: "ডেট টাইম",
   excerpt: """
   এলিক্সিরে সময় সংক্রান্ত কাজ করা
@@ -72,7 +72,7 @@ true
 অসুবিধা হলো, এতে কোন টাইমজোন সাপোর্ট নাইঃ
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/el/basics/date_time.md
+++ b/lessons/el/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.1",
+  version: "1.2.2",
   title: "Ημερομηνία και Ώρα",
   excerpt: """
   Πως δουλεύουμε με την ώρα στην Elixir
@@ -72,7 +72,7 @@ true
 Το μειονέκτημά της είναι η έλειψη υποστήριξης για ζώνες ώρας:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/en/basics/date_time.md
+++ b/lessons/en/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "Date and Time",
   excerpt: """
   Working with time in Elixir.

--- a/lessons/en/basics/date_time.md
+++ b/lessons/en/basics/date_time.md
@@ -72,7 +72,7 @@ The first is `NaiveDateTime`.
 Its disadvantage is lack of timezone support:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2022-01-21 19:55:10.008965]
 ```
 

--- a/lessons/es/basics/date_time.md
+++ b/lessons/es/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.0",
+  version: "1.1.1",
   title: "Fecha y Hora",
   excerpt: """
   Trabajando con tiempos en Elixir.
@@ -71,7 +71,7 @@ La primera es `NaiveDateTime`.
 Su desventaja es la falta de soporte para la zona horaria:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/fr/basics/date_time.md
+++ b/lessons/fr/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.1",
+  version: "1.1.2",
   title: "Date et Heure",
   excerpt: """
   Travailler avec le temps en Elixir.
@@ -72,7 +72,7 @@ La première est `NaiveDateTime`.
 Son inconvénient est qu'elle n'offre pas le support des fuseaux horaires.
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/id/basics/date_time.md
+++ b/lessons/id/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "Tanggal dan Waktu",
   excerpt: """
   Bekerja dengan waktu di Elixir.
@@ -70,7 +70,7 @@ Ada dua jenis *struct* yang berisi tanggal dan waktu sekaligus di Elixir.
 Yang pertama adalah `NaiveDateTime` yang memiliki kekurangan dalam dukungan zona waktu.
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2022-01-21 19:55:10.008965]
 ```
 

--- a/lessons/ja/basics/date_time.md
+++ b/lessons/ja/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.1",
+  version: "1.1.2",
   title: "日付と時間",
   excerpt: """
   Elixirで時間を扱ってみましょう。
@@ -72,7 +72,7 @@ Elixirには日付と時間を同時に含む構造体が2種類あります。
 この構造体のデメリットはタイムゾーンのサポートが無いという点です:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/ko/basics/date_time.md
+++ b/lessons/ko/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "날짜와 시간",
   excerpt: """
   Elixir에서 시간을 다루어 봅시다.
@@ -72,7 +72,7 @@ true
 이 모듈에는 타임존 지원이 없다는 단점이 있습니다.
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/pl/basics/date_time.md
+++ b/lessons/pl/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "Data i czas",
   excerpt: """
   Obsługa czasu w Elixirze.
@@ -72,7 +72,7 @@ Pierwszym z nich jest `NaiveDateTime`.
 Jego wadą jest brak danych o strefie czasowej:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/pt/basics/date_time.md
+++ b/lessons/pt/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "Data e Tempo",
   excerpt: """
   Trabalhando com tempo em Elixir.
@@ -74,7 +74,7 @@ O primeiro dos dois é o `NaiveDateTime`.
 A desvantagem é a falta de suporte para fuso horário:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2022-01-21 19:55:10.008965]
 ```
 

--- a/lessons/ru/basics/date_time.md
+++ b/lessons/ru/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.2.0",
+  version: "1.2.1",
   title: "Дата и время",
   excerpt: """
   Работа с временем в Elixir.
@@ -72,7 +72,7 @@ true
 Её недостаток - отсутствие поддержки часовых поясов:
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2022-01-21 19:55:10.008965]
 ```
 

--- a/lessons/zh-hans/basics/date_time.md
+++ b/lessons/zh-hans/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.0",
+  version: "1.1.1",
   title: "日期和时间",
   excerpt: """
   Elixir 中有关时间和日期的处理
@@ -67,7 +67,7 @@ true
 Elixir 中有两种结构体既包含时间信息，又包含日期信息。我们首先来看 `NaiveDateTime`。 它的一个不足是缺少时区的信息。
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 

--- a/lessons/zh-hant/basics/date_time.md
+++ b/lessons/zh-hant/basics/date_time.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.0",
+  version: "1.1.1",
   title: "日期與時間",
   excerpt: """
   在 Elixir 中處理時間。
@@ -72,7 +72,7 @@ true
 缺點是缺少時區支援：
 
 ```elixir
-iex(15)> NaiveDateTime.utc_now
+iex> NaiveDateTime.utc_now
 ~N[2029-01-21 19:55:10.008965]
 ```
 


### PR DESCRIPTION
In the NaiveDateTime example, the code snippet includes the input count for iex. This serves no purpose, and might be confusing.