### PR TITLE
[PT] Update GenStage lesson

### DIFF
--- a/lessons/pt/data_processing/genstage.md
+++ b/lessons/pt/data_processing/genstage.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.1",
+  version: "1.1.3",
   title: "GenStage",
   excerpt: """
   Nesta lição vamos examinar de perto o GenStage, para que serve e como podemos usá-lo em nossas aplicações.


### PR DESCRIPTION
## Description

The differences found between the English and Portuguese versions are not relevant enough to justify a difference in the versions, given that most of the adjustments are related to an alternative markdown syntax, not impacting the style/rendering of the text.

> obs: The adjustments from v1.1.2 in the English version were already in v1.1.1 of the Portuguese version