### PR TITLE
Patch/fix error message

### DIFF
--- a/lessons/en/basics/basics.md
+++ b/lessons/en/basics/basics.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.3.0",
+  version: "1.3.1",
   title: "Basics",
   excerpt: """
   Getting started, basic data types, and basic operations.
@@ -210,7 +210,7 @@ true
 iex> not false
 true
 iex> 42 and true
-** (ArgumentError) argument error: 42
+** (BadBooleanError) expected a boolean on left-side of "and", got: 42
 iex> not 42
 ** (ArgumentError) argument error
 ```

--- a/lessons/ja/basics/basics.md
+++ b/lessons/ja/basics/basics.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.3.0",
+  version: "1.3.1",
   title: "基本",
   excerpt: """
   入門、基本データ型、そして基本的な演算。
@@ -206,7 +206,7 @@ true
 iex> not false
 true
 iex> 42 and true
-** (ArgumentError) argument error: 42
+** (BadBooleanError) expected a boolean on left-side of "and", got: 42
 iex> not 42
 ** (ArgumentError) argument error
 ```


### PR DESCRIPTION
`42 and true` in Boolean section no longer throws `ArgumentError`.

Tested in the following environment.

- Erlang/OTP 26 [erts-14.1.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns]
- Interactive Elixir (1.15.7) 

```
iex(1)> 42 and true
** (BadBooleanError) expected a boolean on left-side of "and", got: 42
    iex:1: (file)
```