### PR TITLE
[zh_hant] fix lessons functions example typo

### DIFF
--- a/lessons/zh-hant/basics/functions.md
+++ b/lessons/zh-hant/basics/functions.md
@@ -247,11 +247,11 @@ person = %{name: "Fred", age: "95", favorite_color: "Taupe"}
 "Hello, Fred"
 %{age: "95", favorite_color: "Taupe", name: "Fred"}
 # call with only the name key
-...> Greeter4.hello(%{name: "Fred"})
+...> Greeter2.hello(%{name: "Fred"})
 "Hello, Fred"
 %{name: "Fred"}
 # call without the name key
-...> Greeter4.hello(%{age: "95", favorite_color: "Taupe"})
+...> Greeter2.hello(%{age: "95", favorite_color: "Taupe"})
 ** (FunctionClauseError) no function clause matching in Greeter2.hello/1
 
     The following arguments were given to Greeter2.hello/1:


### PR DESCRIPTION
In the context, it did not define the Module `Greeter4`. So the code example should call `Greeter2.hello`, not `Greeter4.hello`. The error message also mention to `Greeter2.hello`.

Thank you.