### PR TITLE
Fix moved options from Task.Supervisor child tuple to Task.Supervisor.start_child/3

### DIFF
--- a/lessons/en/advanced/otp_supervisors.md
+++ b/lessons/en/advanced/otp_supervisors.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.2",
+  version: "1.1.3",
   title: "OTP Supervisors",
   excerpt: """
   Supervisors are specialized processes with one purpose: monitoring other processes.
@@ -163,7 +163,7 @@ Including the `Task.Supervisor` is no different than other supervisors:
 
 ```elixir
 children = [
-  {Task.Supervisor, name: ExampleApp.TaskSupervisor, restart: :transient}
+  {Task.Supervisor, name: ExampleApp.TaskSupervisor}
 ]
 
 {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
@@ -173,10 +173,10 @@ The major difference between `Supervisor` and `Task.Supervisor` is that its defa
 
 ### Supervised Tasks
 
-With the supervisor started we can use the `start_child/2` function to create a supervised task:
+With the supervisor started we can use the `start_child/3` function to create a supervised task and pass in our options:
 
 ```elixir
-{:ok, pid} = Task.Supervisor.start_child(ExampleApp.TaskSupervisor, fn -> background_work end)
+{:ok, pid} = Task.Supervisor.start_child(ExampleApp.TaskSupervisor, fn -> IO.puts("Background Work Done") end, [restart: :transient])
 ```
 
 If our task crashes prematurely it will be re-started for us.

--- a/lessons/en/advanced/otp_supervisors.md
+++ b/lessons/en/advanced/otp_supervisors.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.1.3",
+  version: "1.2.0",
   title: "OTP Supervisors",
   excerpt: """
   Supervisors are specialized processes with one purpose: monitoring other processes.

--- a/lessons/en/advanced/protocols.md
+++ b/lessons/en/advanced/protocols.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.0.1",
+  version: "1.1.0",
   title: "Protocols",
   excerpt: """
   In this lesson we are going to look at Protocols, what they are, and how we use them in Elixir.
@@ -92,8 +92,7 @@ defimpl AsAtom, for: Map do
 end
 ```
 
-Here we've defined our protocol and it's expected function, `to_atom/1`, along with implementations for a few types.
-Now that we have our protocol, let's put it to use in IEx:
+Here we've defined our protocol and it's expected function, `to_atom/1`, along with implementations for a few types. What the `defdelegate` macro does is simply forward the `to_atom/1` function to be executed by the specified module. Now that we have our protocol, let's put it to use in IEx:
 
 ```elixir
 iex> import AsAtom


### PR DESCRIPTION
Running the code as was resulted in a return value of {:restart, :transient} in the Task.Supervisor.start_child/3 function