### PR TITLE
Update pattern_matching.md

### DIFF
--- a/lessons/pt/basics/pattern_matching.md
+++ b/lessons/pt/basics/pattern_matching.md
@@ -56,7 +56,7 @@ iex> {:ok, value} = {:error}
 
 Acabamos de aprender que o operador match manuseia atribuições quando o lado esquerdo da associação é uma variável. Em alguns casos este comportamento de reassociação de variável é algo não desejável. Para estas situações, nós temos o operador pin:`^`.
 
-Quando fixamos a variável em associação ao valor existente ao invés de reassociar a um novo valor. Vamos ver como isso funciona:
+Quando fixamos uma variável, nós a associamos ao valor existente ao invés de reassociar a um novo valor. Vamos ver como isso funciona:
 
 ```elixir
 iex> x = 1


### PR DESCRIPTION
There's a typo in line 59 that makes the sentence meaningless.

The correct translation of the sentence "When we pin a variable *we* match on the existing value rather than rebinding to a new one."

...is the one suggested in the commit:
"Quando fixamos uma variável, *nós* a associamos ao valor existente ao invés de reassociar a um novo valor."