### PR TITLE
Update basics.md

### DIFF
--- a/lessons/en/ecto/basics.md
+++ b/lessons/en/ecto/basics.md
@@ -221,7 +221,7 @@ iex> name
 Similarly, we can update our schemas just as we would any other map or struct in Elixir:
 
 ```elixir
-iex> %{person | age: 18}
+iex> person = %{person | age: 18}
 %Friends.Person{age: 18, name: "Tom"}
 iex> Map.put(person, :name, "Jerry")
 %Friends.Person{age: 18, name: "Jerry"}


### PR DESCRIPTION
I think there is a typo on either the query or the result. If you follow the example in the lesson, you get this: 

```
iex> %{person | age: 18}
%Friends.Person{
  __meta__: #Ecto.Schema.Metadata<:built, "people">,
  id: nil,
  name: "Tom",
  age: 18
}
iex> Map.put(person, :name, "Jerry")
%Friends.Person{
  __meta__: #Ecto.Schema.Metadata<:built, "people">,
  id: nil,
  name: "Jerry",
  age: 11
}
```
which does not match the result of the lesson example. 
To match the result of the lesson example, it should be `iex> person = %{person | age: 18}`
Or the result of the second query should be `%Friends.Person{age: 11, name: "Jerry"}`
