### PR TITLE
Correct a typo

### DIFF
--- a/lessons/en/advanced/protocols.md
+++ b/lessons/en/advanced/protocols.md
@@ -92,7 +92,7 @@ defimpl AsAtom, for: Map do
 end
 ```
 
-Here we've defined our protocol and it's expected function, `to_atom/1`, along with implementations for a few types.
+Here we've defined our protocol and its expected function, `to_atom/1`, along with implementations for a few types.
 Now that we have our protocol, let's put it to use in IEx:
 
 ```elixir


### PR DESCRIPTION
Here you would want to use "its" (which is possessive) rather than the contraction of "it is".