### PR TITLE
Replace deprecated url for nerves lesson

### DIFF
--- a/lessons/el/misc/nerves.md
+++ b/lessons/el/misc/nerves.md
@@ -200,7 +200,7 @@ _Αντιμετώπιση προβλημάτων: Αν δεν έχετε ένα 
 Για παράδειγμα, για όλα τα μοντέλα Raspberry Pi, υπάρχει μόνο μια λυχνία LED ενσωματομένη: `led0`.
 Ας την χρησιμοποιήσουμε προσθέτοντας μια γραμμή `config :nerves_leds, names: [green: "led0"]` στο αρχείο `config/config.exs`.
 
-Για άλλες συσκευές, μπορείτε να ρίξετε μια ματιά στο [αντίστοιχο μέρος του πρότζεκτ nerves_examples](https://github.com/nerves-project/nerves_examples/tree/main/hello_leds/config).
+Για άλλες συσκευές, μπορείτε να ρίξετε μια ματιά στο [αντίστοιχο μέρος του πρότζεκτ nerves_examples]((https://github.com/nerves-project/nerves_examples/tree/main/blinky/config).
 
 Αφού ρυθμίσουμε την λυχνία LED, σίγουρα θα πρέπει κάπως να την ελέγξουμε.
 Για να το κάνουμε αυτό, θα προσθέσουμε έναν GenServer (δείτε λεπτομέριες στο μάθημα [OTP Concurrency](/el/lessons/advanced/otp_concurrency)) στο αρχείο `lib/network_led/blinker.ex` με αυτά τα περιεχόμενα:

--- a/lessons/en/misc/nerves.md
+++ b/lessons/en/misc/nerves.md
@@ -200,7 +200,7 @@ After setting up the dependency, you need to configure the LED list for the give
 For example, for all Raspberry Pi models, there is only one LED onboard: `led0`.
 Let's use it by adding a `config :nerves_leds, names: [green: "led0"]` line to the `config/config.exs`.
 
-For other devices, you can take a look at the [corresponding part of the nerves_examples project](https://github.com/nerves-project/nerves_examples/tree/main/hello_leds/config).
+For other devices, you can take a look at the [corresponding part of the nerves_examples project]((https://github.com/nerves-project/nerves_examples/tree/main/blinky/config).
 
 After configuring the LED itself, we surely need to control it somehow.
 To do that, we will add a GenServer (see details about GenServers in [OTP Concurrency](/en/lessons/advanced/otp_concurrency) lesson) in `lib/network_led/blinker.ex` with these contents:

--- a/lessons/ja/misc/nerves.md
+++ b/lessons/ja/misc/nerves.md
@@ -175,7 +175,7 @@ LEDとやり取りするには、[nerves_leds](https://github.com/nerves-project
 
 依存関係を設定したら、特定のデバイスのLEDリストを設定する必要があります。例えば、すべてのRaspberry Piモデルのために、ただ一つのLEDである `led0` が搭載されています。 `config/config.exs` に `config :nerves_leds, names: [green: "led0"]` を追加して使用しましょう。
 
-他のデバイスについては、[nerves_examplesプロジェクトで対応する部分](https://github.com/nerves-project/nerves_examples/tree/main/hello_leds/config) を参照してください。
+他のデバイスについては、[nerves_examplesプロジェクトで対応する部分]((https://github.com/nerves-project/nerves_examples/tree/main/blinky/config) を参照してください。
 
 LED自体を設定したら、どうにかしてそれを制御する必要があります。そのために、以下の内容を含む `lib/network_led/blinker.ex` にGenServerを追加します（[OTP Concurrency](/ja/lessons/advanced/otp_concurrency) レッスンのGenServerについての詳細を参照）。
 

--- a/lessons/pt/misc/nerves.md
+++ b/lessons/pt/misc/nerves.md
@@ -200,7 +200,7 @@ Depois de instalar a dependência, você precisa configurar a lista de LED para 
 Por exemplo, para todos modelos de Raspberry Pi, existe apenas um LED onboard: `led0`.
 Vamos usá-lo adicionando uma linha `config :nerves_leds, names: [green: "led0"]` ao arquivo `config/config.exs`.
 
-Para outros dispositivos, você pode dar uma olhada na [parte correspondente do projeto nerves_example](https://github.com/nerves-project/nerves_examples/tree/main/hello_leds/config).
+Para outros dispositivos, você pode dar uma olhada na [parte correspondente do projeto nerves_example]((https://github.com/nerves-project/nerves_examples/tree/main/blinky/config).
 
 Depois de configurar o LED em si, nós certamente precisamos controlá-lo de alguma forma.
 Para fazer isso, nós adicionaremos um GenServer (veja detalhes sobre GenServers na lição [Concorrência OTP](/pt/lessons/advanced/otp_concurrency)) em `lib/network_led/blinker.ex` com esse conteúdo:


### PR DESCRIPTION
Hey, everyone!

`hello_leds` example is deprecated due to [this PR](https://github.com/nerves-project/nerves_examples/pull/251).
LInk is replaced with [new blinky link](https://github.com/nerves-project/nerves_examples/tree/main/blinky/config).