### PR TITLE
[id] lesson collections - `1.3.1` -> `1.3.2`

### DIFF
--- a/lessons/id/basics/collections.md
+++ b/lessons/id/basics/collections.md
@@ -1,69 +1,69 @@
 %{
-  version: "1.3.1",
+  version: "1.3.2",
   title: "Koleksi",
   excerpt: """
-  List, tuple, keyword lists, dan map.
+  Lists, tuples, keyword lists, dan maps.
   """
 }
 ---
 
-## List
+## Lists
 
-List adalah kumpulan sederhana dari nilai-nilai, bisa berisi beberapa tipe sekaligus; list bisa berisi nilai yang tidak unik (bisa berisi duplikat):
+Lists adalah kumpulan nilai yang dapat mencakup beberapa tipe data; lists juga dapat mencakup nilai yang tidak unik:
 
 ```elixir
 iex> [3.14, :pie, "Apple"]
 [3.14, :pie, "Apple"]
 ```
 
-Elixir mengimplementasikan list sebagai `linked list`.
-Artinya, operasi untuk mendapatkan panjang sebuah list merupakan operasi yang berjalan dalam waktu yang linear (`O(n)`).
-Karenanya, biasanya lebih cepat menambahkan anggota baru di awal list daripada di akhir list:
+Elixir mengimplementasikan list sebagai linked list.
+Ini berarti mengakses panjang sebuah list adalah operasi yang akan berjalan dalam waktu linear (`O(n)`).
+Untuk alasan ini, biasanya lebih cepat untuk melakukan operasi penambahan di awal list (prepend) daripada melakukan operasi penambahan di akhir (append):
 
 ```elixir
 iex> list = [3.14, :pie, "Apple"]
 [3.14, :pie, "Apple"]
-# Penambahan di awal (cepat)
+# Prepending (operasi yang cepat)
 iex> ["π" | list]
 ["π", 3.14, :pie, "Apple"]
-# Penambahan di akhir (lambat)
+# Appending (operasi yang lambat)
 iex> list ++ ["Cherry"]
 [3.14, :pie, "Apple", "Cherry"]
 ```
 
-### Penggandengan List
+### Penggabungan List
 
-Penggandengan list menggunakan operator `++/2`:
+Penggabungan list menggunakan operator `++/2`:
 
 ```elixir
 iex> [1, 2] ++ [3, 4, 1]
 [1, 2, 3, 4, 1]
 ```
 
-Sebuah catatan tentang format nama (`++/2`) yang digunakan di atas:
-Dalam Elixir (dan Erlang, bahasa yang digunakan untuk membangun Elixir), sebuah nama fungsi atau operator memiliki dua komponen: nama yang kamu berikan (di sini `++`) dan _arity_ nya.
-Arity (jumlah parameter) adalah bagian inti (penting) dari pembicaraan tentang kode Elixir (dan Erlang).
-Arity merupakan jumlah argumen yang bisa diterima oleh sebuah fungsi (dua, dalam kasus ini).
-Arity dan nama fungsinya digabungkan dengan garis miring. Kita akan membicarakannya nanti; saat ini, pengetahuan ini akan membantu kamu untuk memahami notasi ini.
+Catatan tambahan tentang penulisan format yang digunakan di atas (`++/2`):
+Di Elixir (dan Erlang, di mana Elixir dibangun di atasnya), nama sebuah fungsi atau operator memiliki dua komponen yaitu: nama yang kamu berikan (di sini adalah `++`) dan _ariti-nya_.
+Arity adalah bagian inti dari pembicaraan tentang kode Elixir (dan Erlang).
+Ini adalah jumlah argumen yang dibutuhkan oleh fungsi yang diberikan (dua, dalam kasus ini).
+Ariti dan nama yang diberikan digabungkan dengan garis miring. Kita akan membahas lebih lanjut tentang hal ini nanti; pengetahuan ini akan membantu kamu memahami notasi untuk saat ini.
 
 ### Pengurangan List
 
-Dukungan terhadap pengurangan diberikan melalui operator `--/2`; pengurangan nilai yang tidak ada dalam list tidak menghasilkan error:
+Dukungan untuk pengurangan list disediakan melalui operator `--/2`; ini operasi saman untuk mengurangi nilai yang tidak ada atau hilang:
 
 ```elixir
 iex> ["foo", :bar, 42] -- [42, "bar"]
 ["foo", :bar]
 ```
 
-Perhatikan nilai yang terulang.
-Setiap elemen yang ada di sebelah kanan akan menghapus elemen pertama dengan nilai yang sama dari sebelah kiri kiri:
+Berhati-hatilah dengan nilai duplikat!.
+Untuk setiap elemen di sebelah kanan, kemunculan pertama elemen tersebut akan dihapus dari list sebelah kiri:
 
 ```elixir
 iex> [1,2,2,3,2,3] -- [1,2,3,2]
 [2, 3]
 ```
 
-**Catatan:** List menggunakan [perbandingan ketat](/id/lessons/basics/basics#perbandingan) untuk mencocokkan nilai. Contoh:
+**Catatan:** Pengurangan list menggunakan [perbandingan ketat](/en/lessons/basics/basics#comparison) untuk menemukan nilai yang cocok.
 
 ```elixir
 iex> [2] -- [2.0]
@@ -72,11 +72,11 @@ iex> [2.0] -- [2.0]
 []
 ```
 
-### Kepala / Ekor
+### Head / Tail
 
-Ketika menggunakan list, kita sering menggunakan kepala (head) dan ekor (tail) dari list tersebut.
-Kepala (Head) adalah elemen pertama dari list dan ekor (tail) adalah sisanya.
-Elixir memiliki dua fungsi yang sangat membantu, `hd` dan `tl`, untuk mengakses keduanya:
+Ketika menggunakan lists, adalah hal umum untuk bekerja dengan head dan tail.
+Head adalah elemen pertama dalam list, sementara tail adalah list yang mengandung elemen-elemen yang sisanya.
+Elixir menyediakan dua fungsi yang membantu kita bekerja dengan head dan tail yaitu `hd` dan `tl`:
 
 ```elixir
 iex> hd [3.14, :pie, "Apple"]
@@ -85,7 +85,8 @@ iex> tl [3.14, :pie, "Apple"]
 [:pie, "Apple"]
 ```
 
-Di samping kedua fungsi tersebut, kamu juga bisa menggunakan [pencocokan pola](/id/lessons/basics/pattern_matching) dan operator `|` untuk memisahkan kepala (head) list dan ekornya (tail). Kita akan melihat pola ini di pelajaran-pelajaran selanjutnya:
+Selain fungsi-fungsi yang telah disebutkan di atas, kamu dapat menggunakan [pattern matching](/en/lessons/basics/pattern_matching) dan operator cons `|` untuk membagi sebuah list menjadi head dan tail. Kita akan mempelajari lebih lanjut tentang pola ini di pelajaran selanjutnya:
+
 
 ```elixir
 iex> [head | tail] = [3.14, :pie, "Apple"]
@@ -96,18 +97,19 @@ iex> tail
 [:pie, "Apple"]
 ```
 
-## Tuple
+## Tuples
 
-Tuple mirip dengan list, hanya saja ia disimpan secara berturutan di memori.
-Ini membuat panjang tuple mudah dan cepat untuk diakses namun membutuhkan sumber daya lebih untuk mengubah/memodifikasinya; tuple yang baru harus disalin keseluruhannya ke memori baru.
-Tuple didefinisikan menggunakan kurung kurawal:
+Tuples mirip dengan lists, tetapi disimpan secara berdekatan di memori.
+Hal ini membuat pengaksesan panjangnya adalah operasi yang cepat tetapi modifikasinya adalah operasi yang mahal; karena tuple baru harus disalin seluruhnya ke memori.
+Tuples didefinisikan dengan kurung kurawal:
 
 ```elixir
 iex> {3.14, :pie, "Apple"}
 {3.14, :pie, "Apple"}
 ```
 
-Umumnya tuple digunakan sebagai mekanisme untuk mengembalikan informasi tambahan dari fungsi; manfaat dari ini akan lebih jelas ketika kita mempelajari [pencocokan pola (pattern matching)](/id/lessons/basics/pattern_matching):
+Tuple adalah hal yang umum yang digunakan sebagai mekanisme untuk mengembalikan informasi tambahan dari fungsi; kegunaannya akan lebih jelas ketika kita masuk ke [pattern matching] (/en/lessons/basics/pattern_matching):
+
 
 ```elixir
 iex> File.read("path/to/existing/file")
@@ -116,10 +118,10 @@ iex> File.read("path/to/unknown/file")
 {:error, :enoent}
 ```
 
-## Keyword list
+## Keyword lists
 
-Daftar kata kunci (keyword list) dan map adalah koleksi asosiatif dalam Elixir.
-Dalam Elixir, sebuah keyword list adalah sejenis list khusus berisi tuple yang elemen pertamanya adalah sebuah atom; kinerjanya serupa dengan list:
+Keyword lists dan maps adalah koleksi asosiatif dari Elixir.
+Di Elixir, Keyword lists adalah list khusus yang berisi tupel dua elemen yang elemen pertamanya adalah atom; cara kerjanya sama seperti list:
 
 ```elixir
 iex> [foo: "bar", hello: "world"]
@@ -128,19 +130,19 @@ iex> [{:foo, "bar"}, {:hello, "world"}]
 [foo: "bar", hello: "world"]
 ```
 
-Ketiga karakteristik keyword list mengindikasikan keutamaannya:
+Tiga karakteristik utama dari keyword list menunjukkan betapa pentingnya struktur ini:
 
-+ Kunci (key)nya adalah atom.
-+ Kuncinya berurutan.
-+ Kuncinya tidak harus unik.
+- Keys (kuncinya) harus berupa atom.
+- Keys memiliki urutan sesuai dengan yang ditentukan oleh pengembang.
+- Keys tidak harus unik.
 
-Untuk alasan inilah keyword list paling sering digunakan untuk memasukkan parameter ke fungsi.
+Untuk alasan ini, keyword lists umumnya digunakan untuk meneruskan opsi ke fungsi-fungsi di Elixir.
 
-## Map
+## Maps
 
-Dalam Elixir map adalah sarana yang paling sering digunakan untuk penyimpanan key-value (kunci-nilai).
-Tidak seperti keyword list, kita bisa menggunakan menggunakan dari tipe apapun untuk dijadikan kunci dan tidak perlu urut.
-Kamu bisa mendefinisikan sebuah map dengan sintaks `%{}`:
+Di Elixir, maps adalah pilihan utama untuk penyimpanan pasangan key-value.
+Berbeda dengan keyword list, map memungkinkan key dari berbagai tipe data dan tidak memiliki urutan.
+Kamu dapat mendefinisikan map menggunakan sintaks `%{}`:
 
 ```elixir
 iex> map = %{:foo => "bar", "hello" => :world}
@@ -151,7 +153,7 @@ iex> map["hello"]
 :world
 ```
 
-Sejak Elixir 1.2, variabel bisa digunakan sebagai key dari map:
+Pada Elixir 1.2, variabel diperbolehkan sebagai key pada map:
 
 ```elixir
 iex> key = "hello"
@@ -160,14 +162,14 @@ iex> %{key => "world"}
 %{"hello" => "world"}
 ```
 
-Jika sebuah duplikasi ditambahkan ke sebuah map, data yang baru akan mengubah yang lama:
+Jika ada duplikat yang ditambahkan ke map, ia akan mengganti nilai sebelumnya:
 
 ```elixir
 iex> %{:foo => "bar", :foo => "hello world"}
 %{foo: "hello world"}
 ```
 
-Sebagaimana bisa dilihat di tampilan output di atas, ada sintaks khusus untuk map yang seluruh kuncinya adalah atom:
+Seperti yang kita lihat pada output di atas, ada ciri khusus untuk map yang hanya berisi atom keys:
 
 ```elixir
 iex> %{foo: "bar", hello: "world"}
@@ -176,7 +178,7 @@ iex> %{foo: "bar", hello: "world"} == %{:foo => "bar", :hello => "world"}
 true
 ```
 
-Sebagai tambahan, ada sebuah sintaks spesial untuk mengakses kunci atom:
+Selain itu, ada sintaks untuk mengambil nilai untuk key yang berjenis atom:
 
 ```elixir
 iex> map = %{foo: "bar", hello: "world"}
@@ -185,7 +187,7 @@ iex> map.hello
 "world"
 ```
 
-Hal menarik lain mengenai map adalah tersedianya sintaks tersendiri untuk memperbarui nilai-nilainya (catatan: ini akan membuat map baru):
+Satu lagi sifat menarik dari map adalah kemampuannya untuk menyediakan sintaks khusus dalam melakukan pembaruan (perlu dicatat: ini akan menghasilkan map baru):
 
 ```elixir
 iex> map = %{foo: "bar", hello: "world"}
@@ -194,9 +196,9 @@ iex> %{map | foo: "baz"}
 %{foo: "baz", hello: "world"}
 ```
 
-**Catatan**: sintaks ini hanya bisa digunakan untuk memperbarui nilai sebuah kunci yang sudah ada di dalam map! Jika kunci tersebut belum ada, error `KeyError` akan ditimbulkan.
+**Catatan**: sintaks ini hanya berfungsi untuk memperbarui key yang sudah ada di dalam map! Jika kunci tersebut tidak ada, akan muncul `KeyError`.
 
-Untuk menambahkan kunci baru, gunakan [`Map.put/3`](https://hexdocs.pm/elixir/Map.html#put/3).
+Untuk membuat key yang baru, gunakan [`Map.put/3`](https://hexdocs.pm/elixir/Map.html#put/3)
 
 ```elixir
 iex> map = %{hello: "world"}


### PR DESCRIPTION
This PR updates the Indonesian translation of the `lessons/id/basics/collections.md` to align with version `1.3.2`. I've made the following improvements:

- Updated the content to match the latest version (1.3.2) of the lesson.
- Adjusted the tone and style for better flow and readability in Indonesian.
- Corrected any typo errors and inconsistencies in the translation.