### PR TITLE
[id] lesson enum - `1.9.1` -> `1.9.2`

### DIFF
--- a/lessons/id/basics/enum.md
+++ b/lessons/id/basics/enum.md
@@ -1,18 +1,19 @@
 %{
-  version: "1.9.1",
+  version: "1.9.2",
   title: "Enum",
   excerpt: """
-  Sekumpulan algoritma untuk melakukan enumerasi atas enumerables.
+  Sekumpulan Algoritma untuk Enumerasi atas Enumerable.
   """
 }
 ---
 
-## Enum
+## Gambaran Umum
 
-Modul `Enum` mencakup lebih dari 70 fungsi untuk bekerja pada enumrables. Semua koleksi yang sudah kita pelajari dalam [pelajaran sebelumnya](/id/lessons/basics/collections), dengan pengecualian tuple, adalah enumerables.
+Modul `Enum` memiliki lebih dari 70 fungsi untuk bekerja dengan koleksi enumerable.
+Semua koleksi yang telah kita pelajari pada [pelajaran sebelumnya](/en/lessons/basics/collections) dengan pengecualian tuples adalah enumerable.
 
-Pelajaran ini hanya akan mencakup sebagian dari fungsi yang ada, akan tetapi kita sebenarnya dapat memeriksa semuanya sendiri.
-Mari lakukan sedikit eksperimen pada IEx.
+Pelajaran kali ini hanya akan membahas sebagian kecil dari fungsi-fungsi enumerable yang tersedia, namun kita dapat mencobanya sendiri.
+Mari kita lakukan sebuah percobaan kecil di IEx.
 
 ```elixir
 iex> Enum.__info__(:functions) |> Enum.each(fn({function, arity}) ->
@@ -27,15 +28,15 @@ at/3
 ...
 ```
 
-Dengan ini, jelas bahwa kita memiliki sejumlah fungsionalias yang sangat banyak, dan itu semua bukan tanpa alasan. Enumerasi adalah inti dari pemrograman fungsional, dan dikombinasikan dengan fasilitas lain Elixir, hal itu dapat sangat membantu para pengembang (developer).
+Dengan menggunakan ini, kita bisa lihat bahwa banyak sekali fungsionalitas yang tersedia, dan itu ada alasan jelas di baliknya. Enumerasi adalah dasar dari pemrograman fungsional, dan jika digabungkan dengan kelebihan lain dari Elixir, ini bisa sangat membantu para developer.
 
-## Fungsi-fungsi umum
+## Fungsi-Fungsi Umum
 
-Untuk daftar lengkap fungsi (functions) silahkan kunjungi dokumentasi resmi [`Enum`](https://hexdocs.pm/elixir/Enum.html); untuk enumerasi lazy gunakan modul [`Stream`](https://hexdocs.pm/elixir/Stream.html).
+For a full list of functions visit the official [`Enum`](https://hexdocs.pm/elixir/Enum.html) docs; for lazy enumeration use the [`Stream`](https://hexdocs.pm/elixir/Stream.html) module.
 
 ### all?
 
-Ketika menggunakan `all?/2`, dan banyak `Enum`, kita menyediakan sebuah fungsi untuk diterapkan ke item koleksi kita. Dalam kasus `all?/2`, keseluruhan koleksi harus mengevaluasi `true` jika tidak `false` akan dikembalikan:
+Ketika menggunakan `all?/2`, dan banyak fungsi dari Enum, kita memberikan sebuah fungsi yang akan diterapkan pada setiap item dalam koleksi. Pada kasus all?/2, seluruh koleksi harus menghasilkan nilai `true`, jika tidak, yang akan dikembalikan adalah `false`.
 
 ```elixir
 iex> Enum.all?(["foo", "bar", "hello"], fn(s) -> String.length(s) == 3 end)
@@ -46,7 +47,7 @@ true
 
 ### any?
 
-Tidak seperti di atas, `any?` akan menghasilkan `true` jika setidaknya salah satu item menghasilkan `true`:
+Tidak seperti fungsi di atas, `any?/2` akan mengembalikan `true` jika sekurang-kurangnya satu item yang dievaluasi di dalam koleksi bernilai `true`.
 
 ```elixir
 iex> Enum.any?(["foo", "bar", "hello"], fn(s) -> String.length(s) == 5 end)
@@ -55,18 +56,20 @@ true
 
 ### chunk_every
 
-Jika anda perlu memecah collection jadi kelompok-kelompok yang lebih kecil, `chunk_every/2` adalah fungsi yang dibutuhkan:
+Jika kamu ingin memecah koleksi menjadi beberapa grup yang lebih kecil, `chunk_every/2` adalah fungsi yang mungkin kamu cari:
 
 ```elixir
 iex> Enum.chunk_every([1, 2, 3, 4, 5, 6], 2)
 [[1, 2], [3, 4], [5, 6]]
 ```
 
-Ada beberapa opsi untuk `chunk_every/4` tapi kita tidak akan membahas lebih dalam, lihat [`dokumentasi resmi dari fungsi ini`](https://hexdocs.pm/elixir/Enum.html#chunk_every/4) untuk belajar lebih jauh.
+Ada beberapa opsi untuk `chunk_every/4` tetapi kita tidak akan membahasnya, silahkan cek [dokumentasi resmi fungsi ini](https://hexdocs.pm/elixir/Enum.html#chunk_every/4) untuk mempelajari lebih lanjut.
 
 ### chunk_by
 
-Jika kita butuh mengelompokkan koleksi kita berdasarkan selain ukuran, kita dapat gunakan fungsi `chunk_by/2`. Fungsi ini membutuhkan enumerable dan sebuah fungsi, dan ketika hasil kembali fungsi tersebut berubah, sebuah kelompok baru dimulai untuk penciptaan selanjutnya. Pada contoh di bawah ini, tiap string dengan panjang yang sama dikelompokkan sampai kita bertemu string dengan panjang yang berbeda:
+Jika kita perlu mengelompokkan koleksi berdasarkan sesuatu selain ukurannya, kita bisa menggunakan fungsi `chunk_by/2`.
+Fungsi ini menerima sebuah enumerable dan sebuah fungsi, lalu akan membuat grup baru setiap kali hasil dari fungsi tersebut berubah.
+Pada contoh di bawah ini, setiap string dengan panjang yang sama dikelompokkan bersama hingga kita menemukan string dengan panjang yang berbeda, yang akan memulai grup baru.
 
 ```elixir
 iex> Enum.chunk_by(["one", "two", "three", "four", "five"], fn(x) -> String.length(x) end)
@@ -77,17 +80,17 @@ iex> Enum.chunk_by(["one", "two", "three", "four", "five", "six"], fn(x) -> Stri
 
 ### map_every
 
-Terkadang membingkah (chungking) keluar sebuah koleksi tidak cukup untuk apa yang kita butuhkan. Jika hal tersebut pada kasus ini, `map_every/3` dapat sangatlah berguna untuk mengenai setiap item `nth`, selalu mengenai yang pertama.
+Terkadang, membagi koleksi menjadi beberapa bagian saja tidak cukup untuk apa yang kita butuhkan. Jika itu terjadi, map_every/3 bisa sangat berguna untuk memproses setiap elemen ke-n, operasi ini selalu dimulai dari elemen pertama.
 
 ```elixir
-# Menerapkan fungsi setiap tiga item
+# Apply function every three items
 iex> Enum.map_every([1, 2, 3, 4, 5, 6, 7, 8], 3, fn x -> x + 1000 end)
 [1001, 2, 3, 1004, 5, 6, 1007, 8]
 ```
 
 ### each
 
-Jika kita perlu melakukan iterasi atas sebuah collection tanpa menghasilkan sebuah value baru, kita gunakan `each/2`:
+Terkadang, kita perlu melakukan iterasi pada sebuah koleksi tanpa menghasilkan nilai baru. Untuk kasus seperti ini, kita bisa menggunakan `each/2`.
 
 ```elixir
 iex> Enum.each(["one", "two", "three"], fn(s) -> IO.puts(s) end)
@@ -97,11 +100,11 @@ three
 :ok
 ```
 
-__Catatan__: Fungsi `each/2` mengembalikan atom `:ok`.
+__Catatan__: Fungsi `each/2` akan mengembalikan atom `:ok`.
 
 ### map
 
-Untuk menerapkan fungsi kita terhadap setiap item dan menghasilkan sebuah collection baru, lihatlah fungsi `map/2`:
+Untuk menerapkan fungsi kita ke setiap item dan menghasilkan koleksi baru, gunakan fungsi `map/2`.
 
 ```elixir
 iex> Enum.map([0, 1, 2, 3], fn(x) -> x - 1 end)
@@ -110,14 +113,14 @@ iex> Enum.map([0, 1, 2, 3], fn(x) -> x - 1 end)
 
 ### min
 
-`min/1` menemukan nilai terkecil dalam koleksi:
+Fungsi `min/1` berfungsi untuk mencari nilai minimal dalam koleksi:
 
 ```elixir
 iex> Enum.min([5, 3, 0, -1])
 -1
 ```
 
-`min/2` juga melakukan hal yang sama, namun jika enumerable kosong, itu memperbolehkan kita menentukan fungsi untuk menghasilkan nilai terkecil.
+Fungsi `min/2` juga melakukan hal yang sama, tetapi dalam kasus di mana koleksi kosong, kita bisa menentukan fungsi untuk membuat nilai minimum.
 
 ```elixir
 iex> Enum.min([], fn -> :foo end)
@@ -126,23 +129,23 @@ iex> Enum.min([], fn -> :foo end)
 
 ### max
 
-`max/1` mengembalikan nilai maksimal dalam koleksi:
+Fungsi `max/1` mengembalikan nilai maksimal dalam koleksi:
 
 ```elixir
 iex> Enum.max([5, 3, 0, -1])
 5
 ```
 
-`max/2` adalah `max/1` apa `min/2` ke `min/1`:
+Fungsi `max/2` memiliki hubungan dengan `max/1` seperti halnya `min/2` dengan `min/1`:
 
 ```elixir
-Enum.max([], fn -> :bar end)
+iex> Enum.max([], fn -> :bar end)
 :bar
 ```
 
 ### filter
 
-Fungsi `filter/2` memungkinkan kita menyaring collection untuk hanya berisi elemen-elemen yang menghasilkan `true` saat dievaluasi menggunakan fungsi yang disediakan.
+Fungsi `filter/2` memungkinkan kita menyaring koleksi sehingga hanya elemen-elemen yang menghasilkan `true` berdasarkan fungsi yang diberikan yang akan dikembalikan nilainya:
 
 ```elixir
 iex> Enum.filter([1, 2, 3, 4], fn(x) -> rem(x, 2) == 0 end)
@@ -151,7 +154,8 @@ iex> Enum.filter([1, 2, 3, 4], fn(x) -> rem(x, 2) == 0 end)
 
 ### reduce
 
-Dengan `reduce/3` kita dapat memeras collection kita menjadi sebuah nilai tunggal. Untuk melakukan ini kita memasukkan sebuah akumulator yang opsional (`10` dalam contoh ini) untuk dimasukkan ke dalam fungsi kita; jika tidak ada akumulator diberikan maka value pertama yang digunakan:
+Dengan fungsi `reduce/3`, kita dapat menyederhanakan koleksi menjadi satu nilai.
+Untuk melakukannya, kita memberikan akumulator opsional (`10` dalam contoh ini) yang akan diteruskan ke dalam fungsi. Jika tidak ada akumulator yang diberikan, elemen pertama dalam enumerable akan digunakan sebagai nilai awal.
 
 ```elixir
 iex> Enum.reduce([1, 2, 3], 10, fn(x, acc) -> x + acc end)
@@ -166,9 +170,9 @@ iex> Enum.reduce(["a","b","c"], "1", fn(x,acc)-> x <> acc end)
 
 ### sort
 
-Mengurutkan collection kita menjadi mudah dengan adanya tidak hanya satu, melainkan dua, fungsi pengurutan.
+Untuk mengurutkan koleksi, kita tidak hanya memiliki satu, tetapi dua fungsi pengurutan.
 
-`sort/1` menggunakan istilah Erlang [term ordering](http://erlang.org/doc/reference_manual/expressions.html#term-comparisons) untuk menentukan urutan yang diurutkan:
+Fungsi `sort/1` menggunakan *term ordering* dari Erlang ([term ordering](http://erlang.org/doc/reference_manual/expressions.html#term-comparisons)) untuk menentukan urutan yang benar.
 
 ```elixir
 iex> Enum.sort([5, 6, 1, 3, -1, 4])
@@ -178,19 +182,19 @@ iex> Enum.sort([:foo, "bar", Enum, -1, 4])
 [-1, 4, Enum, :foo, "bar"]
 ```
 
-Sedangkan `sort/2` mengijinkan kita untuk menyediakan sebuah fungsi pengurutan kita sendiri:
+Sementara itu, fungsi `sort/2` memungkinkan kita menyediakan fungsi pengurutan sendiri.
 
 ```elixir
-# dengan fungsi kita
+# with our function
 iex> Enum.sort([%{:val => 4}, %{:val => 1}], fn(x, y) -> x[:val] > y[:val] end)
 [%{val: 4}, %{val: 1}]
 
-# tanpa fungsi kita
+# without
 iex> Enum.sort([%{:count => 4}, %{:count => 1}])
 [%{count: 1}, %{count: 4}]
 ```
 
-Untuk kemudahan, `sort/2` membolehkan kita untuk memakai `:asc` atau `:desc` sebagai fungsi pengurutan:
+Untuk kenyamanan, fungsi `sort/2` memungkinkan kita memberikan `:asc` atau `:desc` sebagai fungsi pengurutan.
 
 ```elixir
 Enum.sort([2, 3, 1], :desc)
@@ -199,15 +203,16 @@ Enum.sort([2, 3, 1], :desc)
 
 ### uniq
 
-Kita dapat menggunakan `uniq_by/2` untuk membuang duplikasi dari enumerables kita:
+Kita bisa menggunakan fungsi `uniq/1` untuk menghilangkan duplikasi dari koleksi:
 
 ```elixir
 iex> Enum.uniq([1, 2, 3, 2, 1, 1, 1, 1, 1])
 [1, 2, 3]
 ```
+
 ### uniq_by
 
-`uniq_by/2` juga membuang duplikasi dari enumerables, tapi memungkinkan kita untuk menyediakan fungsi yang mengecek keunikan.
+Fungsi `uniq_by/2` juga menghapus duplikasi dari koleksi, tetapi kita bisa memberikan fungsi untuk melakukan perbandingan unik.
 
 ```elixir
 iex> Enum.uniq_by([%{x: 1, y: 1}, %{x: 2, y: 1}, %{x: 3, y: 3}], fn coord -> coord.y end)
@@ -216,30 +221,29 @@ iex> Enum.uniq_by([%{x: 1, y: 1}, %{x: 2, y: 1}, %{x: 3, y: 3}], fn coord -> coo
 
 ## Enum menggunakan operator Capture (&)
 
-Banyak fungsi-fungsi di dalam modul Enum di Elixir menerima fungsi anonim sebagai argumen untuk digunakan pada tiap iterable dari enumerables yang dikirim.
+Banyak fungsi dalam modul Enum di Elixir menerima fungsi anonim (*anonymous function*) sebagai argumen untuk bekerja dengan setiap elemen dalam enumerable yang diberikan.
 
-Fungsi anonim tersebut biasanya ditulis secara singkat menggunakan operator Capture (&).
+Anonymous function ini sering kali ditulis secara singkat menggunakan operator Capture (&).
 
-Berikut adalah beberapa contoh untuk menunjukkan bagaimana operator Capture dapat diimplementasikan dengan modul Enum.
-Tiap versi memiliki fungsionalitas yang setara.
+Berikut adalah beberapa contoh yang menunjukkan bagaimana operator capture dapat diterapkan dengan modul Enum. Setiap versi secara fungsional setara.
 
-### Menggunakan operator capture dengan fungsi anonim
+### Menggunakan operator Capture (&) dengan anonymous function
 
-Di bawah ini adalah contoh tipikal dari sintaks standar ketika mengirim sebuah fungsi anonim ke `Enum.map/2`.
+Di bawah ini adalah contoh sintaks standar ketika meneruskan anonymous function ke `Enum.map/2`.
 
 ```elixir
 iex> Enum.map([1,2,3], fn number -> number + 3 end)
 [4, 5, 6]
 ```
 
-Sekarang kita pakai operator capture (&); menangkap tiap iterasi dari sebuah daftar angka ([1,2,3]) dan memasukkan tiap iterasi ke variabel &1 saat dikirim ke fungsi pemetaan.
+Sekarang kita mengimplementasikan operator capture (&); dengan menangkap setiap elemen dari list angka ([1,2,3]) dan menetapkan setiap elemen tersebut ke variabel &1 saat diproses melalui fungsi `map`.
 
 ```elixir
 iex> Enum.map([1,2,3], &(&1 + 3))
 [4, 5, 6]
 ```
 
-Cara ini dapat di-refactor lebih lanjut dengan memasukkan fungsi anonim dengan operator capture di atas ke dalam sebuah variabel dan menggunakannya di fungsi `Enum.map/2`.
+Ini bisa lebih disederhanakan lagi dengan menetapkan anonymous function sebelumnya yang menggunakan operator Capture ke sebuah variabel, lalu memanggilnya dari fungsi `Enum.map/2`.
 
 ```elixir
 iex> plus_three = &(&1 + 3)
@@ -247,27 +251,27 @@ iex> Enum.map([1,2,3], plus_three)
 [4, 5, 6]
 ```
 
-### Menggunakan operator capture dengan named function
+### Menggunakan operator Capture (&) dengan fungsi bernama
 
-Pertama kita buat named function dan memanggilnya di dalam fungsi anonim yang didefinisikan di `Enum.map/2`.
+Pertama, kita buat sebuah fungsi bernama dan memanggilnya di dalam fungsi anonim yang didefinisikan dalam `Enum.map/2`.
 
 ```elixir
 defmodule Adding do
-def plus_three(number), do: number + 3
+  def plus_three(number), do: number + 3
 end
 
 iex>  Enum.map([1,2,3], fn number -> Adding.plus_three(number) end)
 [4, 5, 6]
 ```
 
-Kemudian kita bisa refactor menggunakan operator capture.
+Selanjutnya kita bisa refactor kodenya untuk menggunakan operator Capture.
 
 ```elixir
 iex> Enum.map([1,2,3], &Adding.plus_three(&1))
 [4, 5, 6]
 ```
 
-Untuk sintaks paling ringkas, kita dapat memanggil named function tanpa menuliskan variabel capture (&1) secara eksplisit.
+Untuk sintaks yang paling ringkas, kita bisa langsung memanggil fungsi bernama tanpa perlu secara eksplisit menangkap variabelnya.
 
 ```elixir
 iex> Enum.map([1,2,3], &Adding.plus_three/1)


### PR DESCRIPTION
This PR updates the Indonesian translation of the `lessons/id/basics/enum.md` to align with version `1.9.2`. I've made the following improvements:

- Updated the content to match the latest version (1.9.2) of the lesson.
- Adjusted the tone and style for better flow and readability in Indonesian.