### PR TITLE
Update enum.md

### DIFF
--- a/lessons/en/basics/enum.md
+++ b/lessons/en/basics/enum.md
@@ -91,6 +91,15 @@ iex> Enum.map_every([1, 2, 3, 4, 5, 6, 7, 8], 3, fn x -> x + 1000 end)
 [1001, 2, 3, 1004, 5, 6, 1007, 8]
 ```
 
+### map
+
+To apply our function to each item and produce a new collection look to the `map/2` function:
+
+```elixir
+iex> Enum.map([0, 1, 2, 3], fn(x) -> x - 1 end)
+[-1, 0, 1, 2]
+```
+
 ### each
 
 It may be necessary to iterate over a collection without producing a new value, for this case we use `each/2`:
@@ -104,15 +113,6 @@ three
 ```
 
 __Note__: The `each/2` function does return the atom `:ok`.
-
-### map
-
-To apply our function to each item and produce a new collection look to the `map/2` function:
-
-```elixir
-iex> Enum.map([0, 1, 2, 3], fn(x) -> x - 1 end)
-[-1, 0, 1, 2]
-```
 
 ### min
 


### PR DESCRIPTION
**Change**
Introduce `map` before `each` for more easy to follow ordering.

**Why?**
While this is an extreme nitpick, I did find the original ordering slightly unintuitive. 

When I read _"It may be necessary to iterate over a collection without producing a new value"_, this led me to waste a few seconds searching for the classic `map` function (this is what the majority of developers be familiar with). 
Since `each` is a less common function, I assumed that I had accidentally missed the `map` function. 