### PR TITLE
Update control_structures.md to fix typo

### DIFF
--- a/lessons/en/basics/control_structures.md
+++ b/lessons/en/basics/control_structures.md
@@ -165,7 +165,7 @@ case Repo.insert(changeset) do
 end
 ```
 
-When we introduce `with/1` we end up with code that clearer and has fewer lines:
+When we introduce `with/1` we end up with code that is clearer and has fewer lines:
 
 ```elixir
 with {:ok, user} <- Repo.insert(changeset),


### PR DESCRIPTION
Fixing a typo with a missing 'is' for the text describing with/1