### PR TITLE
Docs: Add explanation for truthy and falsy values

### DIFF
--- a/lessons/en/basics/basics.md
+++ b/lessons/en/basics/basics.md
@@ -199,6 +199,7 @@ false
 iex> !false
 true
 ```
+In Elixir, the concept of "truthiness" is very simple: only `false` and `nil` are considered falsy. Every other value, including `0`, `""` (empty string), and `[]` (empty list), is considered truthy. This strict rule allows boolean operators like `||`, `&&`, and `!` to work predictably with any data type for conditional logic.
 
 There are three additional operators whose first argument _must_ be a boolean (`true` or `false`):
 


### PR DESCRIPTION
### What is the purpose of this change?

The concept of "truthiness" in Elixir can be a point of confusion for developers coming from other languages where values like `0` or `""` are considered falsy. The current documentation could benefit from a direct and concise explanation of this behavior.

### What is the new behavior?

This PR adds a short paragraph to the relevant section (e.g., "Basic Types" or "Boolean Logic") that explicitly states:

> In Elixir, the concept of "truthiness" is very simple: only `false` and `nil` are considered falsy. Every other value, including `0`, `""` (empty string), and `[]` (empty list), is considered truthy. This strict rule allows boolean operators like `||`, `&&`, and `!` to work predictably with any data type for conditional logic.

This clarification helps users to quickly understand the predictable nature of Elixir's boolean operators.